### PR TITLE
CI: disable host bit-compare on pull requests

### DIFF
--- a/.github/workflows/bit-compare-host.yml
+++ b/.github/workflows/bit-compare-host.yml
@@ -11,7 +11,7 @@ on:
     - main
 
   # Trigger the workflow on all pull requests
-  pull_request: ~
+  # pull_request: ~
 
   # Allow workflow to be dispatched on demand
   workflow_dispatch: ~


### PR DESCRIPTION
Temporarily disables the host bit-compare workflow on pull_request so only the Docker CI runs on PRs. The host workflow remains available on pushes to main and via workflow_dispatch until the host CI infrastructure is in place.