### PR TITLE
Force multio-fdb5 linkage in shared builds to register fdb5 sink

### DIFF
--- a/ifs-source/CMakeLists.txt
+++ b/ifs-source/CMakeLists.txt
@@ -171,12 +171,12 @@ endif()
 if(multio_FOUND)
   set(MULTIO_LIBRARIES)
   if(multio_HAVE_FDB5)
-    # Force the linkage of multio-fdb5 for static builds
-    if(NOT BUILD_SHARED_LIBS)
-      list(APPEND MULTIO_LIBRARIES -Wl,--push-state,--no-as-needed multio-fdb5 -Wl,--pop-state)
-    else()
-      list(APPEND MULTIO_LIBRARIES multio-fdb5)
-    endif()
+    # Force linkage of multio-fdb5 regardless of build type: the library
+    # registers the fdb5 DataSinkFactory via a static C++ initialiser only,
+    # so a --as-needed linker (default on Ubuntu 22.04 / GCC 13) would
+    # otherwise drop it as unreferenced from a shared build, causing
+    # "No DataSinkFactory for [fdb5]" at runtime.
+    list(APPEND MULTIO_LIBRARIES -Wl,--push-state,--no-as-needed multio-fdb5 -Wl,--pop-state)
   endif()
   if(multio_HAVE_FDB4)
     list(APPEND MULTIO_LIBRARIES multio-fdb4 ifsio)


### PR DESCRIPTION
libmultio-fdb5 registers its DataSinkFactory through a static C++ initialiser only, so the linker's --as-needed default (Ubuntu 22.04 / GCC 13) drops it from the NEEDED list of libarpifs and the factory is never registered at runtime, causing "No DataSinkFactory for [fdb5]". Apply --push-state,--no-as-needed unconditionally instead of only for static builds.

(cherry picked from commit fe3ac0638b44181929e021ccbf20d6549ca7ef71)

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 