### PR TITLE
Update bundle for gcc14

### DIFF
--- a/.github/workflows/bit-compare-docker.yml
+++ b/.github/workflows/bit-compare-docker.yml
@@ -32,13 +32,13 @@ jobs:
 
       matrix:
         name:
-          - linux gcc-13
+          - linux gcc-14
 
         include:
 
-          - name: linux gcc-13
+          - name: linux gcc-14
             os: ubuntu-22.04
-            gcc: '13'
+            gcc: '14'
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 180

--- a/bundle.yml
+++ b/bundle.yml
@@ -30,7 +30,7 @@ projects :
 
     - ecbuild :
         git     : https://github.com/ecmwf/ecbuild
-        version : 3.7.0
+        version : 3.7.2
         bundle  : false
 
     - eccodes :
@@ -67,7 +67,7 @@ projects :
 
     - metkit :
         git     : https://github.com/ecmwf/metkit
-        version : 1.8.10
+        version : 1.9.0
         require : eckit
 
     - fdb5 :
@@ -80,13 +80,14 @@ projects :
 
     - atlas :
         git     : https://github.com/ecmwf/atlas
-        version : 0.34.0
+        version : 0.44.0
         require : eckit fckit
         cmake   : >
             ATLAS_ENABLE_TESSELATION=OFF
             ATLAS_ENABLE_TRANS=OFF
             ATLAS_ENABLE_CLANG_TIDY=OFF
             ATLAS_ENABLE_GRIDTOOLS_STORAGE=OFF
+            ATLAS_ENABLE_CUDA=OFF
 
     - multio :
         git     : https://github.com/ecmwf/multio/


### PR DESCRIPTION
### Description

At gcc 14, openifs build failed because of error in building atlas. This PR updates the atlas libs in the bundle.yml so it builds at gcc 14. CI testing with test this test with earlier gcc versions.  

This change also includes an update to metkit (see https://jira.ecmwf.int/browse/SD-117873) and the gcc version in docker ci has been upgraded to gcc 14, so that docker is tested at latest.


 