### PR TITLE
Add prtk PR automation

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,55 @@
+name: check-pr
+
+concurrency:
+  group: prtk-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review, converted_to_draft]
+    branches:
+      - main
+      - main_staging
+      - "openifs-*"
+      - "lts/*"
+      - "mts/*"
+      - "release/*"
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-pr:
+    if: github.repository_owner == 'ecmwf-ifs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 0.6.12
+          enable-cache: false
+
+      - name: Install prtk
+        env:
+          PRTK_READ_ACCESS_TOKEN: ${{ secrets.PRTK_READ_ACCESS }}
+        run: |
+          uv tool install "git+https://${PRTK_READ_ACCESS_TOKEN}@github.com/ecmwf-ifs/prtk"
+
+      - name: Run prtk checks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          prtk check
+          --pr-number "${{ github.event.pull_request.number }}"
+          --default-branch "${{ github.event.repository.default_branch }}"
+          --event-name "${{ github.event_name }}"
+          --event-action "${{ github.event.action }}"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -7,13 +7,6 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, edited, ready_for_review, converted_to_draft]
-    branches:
-      - main
-      - main_staging
-      - "openifs-*"
-      - "lts/*"
-      - "mts/*"
-      - "release/*"
 
 permissions:
   contents: read

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1,0 +1,25 @@
+owner: ecmwf
+
+maintainers:
+  - Adehill
+
+checks:
+  ensure-assignee: {}
+  validate-target-branch:
+    allowed-branches:
+      - main
+      - main_staging
+    allowed-patterns:
+      - "openifs-*"
+      - "lts/*"
+      - "mts/*"
+      - "release/*"
+  assign-reviewers:
+    exclude-author: true
+    exclude-existing: true
+  copyright-audit:
+    reviewer: Adehill
+    skip-label: "prtk:skip-copyright"
+    allowed-holders:
+      - ECMWF
+      - European Centre for Medium-Range Weather Forecasts


### PR DESCRIPTION
## Summary

Adds `prtk` PR automation to openifs. This repository previously had no `MAINTAINERS.yml` and no PR check workflow, so this PR introduces both. openifs does not have a Jira project tied to it, so no `require-jira-ticket` / `sync-jira` checks are enabled.

### `MAINTAINERS.yml` (new)

- `owner: ecmwf`
- `maintainers: [Adehill]` — assignee fallback for `ensure-assignee`, contributes to the reviewer pool
- No `lead_developers`, no `cycle_leads`
- Checks:
  - `ensure-assignee` — every non-draft PR gets one assignee (falls back to `Adehill`)
  - `validate-target-branch` — allowed bases are `main`, `main_staging`, and the patterns `openifs-*`, `lts/*`, `mts/*`, `release/*`. Mirrors the existing trigger filter used by `docker-test.yml`
  - `assign-reviewers` — with `exclude-author` and `exclude-existing`
  - `copyright-audit` — advisory; `Adehill` is the reviewer-of-record; `allowed-holders` is `ECMWF` only (no Météo-France, per the openifs distribution's scope); skippable via the `prtk:skip-copyright` label

### `.github/workflows/check-pr.yml` (new)

- `pull_request_target` triggered on `opened, synchronize, reopened, edited, ready_for_review, converted_to_draft` against the same branch set as `validate-target-branch` allows
- Job gated by `if: github.repository_owner == 'ecmwf-ifs'` so the workflow does not fire on personal forks
- Concurrency group cancels stale runs; 5-minute timeout
- `contents: read`, `pull-requests: write`, `issues: write`
- Installs `prtk` via `uv tool install` using the org-level `PRTK_READ_ACCESS` secret
- No `JIRA_TOKEN` since this repo has no Jira integration
- Calls `prtk check ...` with `--default-branch` and event metadata so `prtk` fetches canonical `MAINTAINERS.yml` from the default branch (`main`)

### Required secrets

`PRTK_READ_ACCESS` is an org-level secret on `ecmwf-ifs` and is already inherited by this repo — no per-repo configuration needed.

### When the new behaviour takes effect

This PR targets `main`, the repository's default branch. `prtk check` reads canonical `MAINTAINERS.yml` from the default branch, so once this PR merges the new policy is immediately what `prtk` consults — no `main_staging → main` propagation lag.

## Test plan

Run these immediately after merge:

- [ ] Open a draft PR to `main` and confirm the `prtk` job skips automation
- [ ] Mark the PR ready for review and confirm: one assignee is set (`Adehill`), reviewers are requested per the rules
- [ ] Open a PR to a non-allowed base (something outside `main`, `main_staging`, `openifs-*`, `lts/*`, `mts/*`, `release/*`) and confirm `validate-target-branch` fails


## Workflow trigger / policy split

The workflow has **no `branches:` filter** on `pull_request_target` — it fires on every PR regardless of target. `prtk`'s `validate-target-branch` (allowed: `main`, `main_staging`, `openifs-*`, `lts/*`, `mts/*`, `release/*`) is the sole policy gate. A narrower trigger would silently skip the check on disallowed bases (the workflow would simply never run on them), so users opening PRs to wrong targets would get no feedback at all.
