### PR TITLE
Modify surf copyrights to match ecland and correct storage.py

### DIFF
--- a/ifs-source/surf/external/surf_inq.F90
+++ b/ifs-source/surf/external/surf_inq.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2001- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURF_INQ(YDSURF,&
                   & KNVTYPES,KNSOTY,PRRCSOIL,PRWSAT,PRWCAP,PRWPWP,PRQWEVAP,PRQWSBCR,&
                   & PRQSNCR,PRWLMAX,PRWSATM,PRWCAPM,PRWPWPM,PRTF1,PRTF2,PRTF3,PRTF4,&
@@ -16,6 +9,13 @@ SUBROUTINE SURF_INQ(YDSURF,&
                   & LD_LESNML, RLEVSNMIN, RLEVSNMAX,&
                   & RLEVSNMIN_GL, RLEVSNMAX_GL)
 
+! (C) Copyright 2001- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**   *SURF_INQ*  Extract information from the surface package
 
 !     Purpose.

--- a/ifs-source/surf/external/surfbc.F90
+++ b/ifs-source/surf/external/surfbc.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2001- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFBC    (YDSURF,KIDIA,KFDIA,KLON,KTILES,KLEVSN,&
  & PTVL   , PCO2TYP, PTVH   ,PSOTY  ,PSDOR ,PCVLC ,PCVHC ,PCURC,&
  & PLAILC  ,PLAIHC, PLAILI, PLAIHI,&
@@ -14,6 +7,13 @@ SUBROUTINE SURFBC    (YDSURF,KIDIA,KFDIA,KLON,KTILES,KLEVSN,&
  & KTVL   ,KCO2TYP, KTVH   ,KSOTY,&
  & PCVL   ,PCVH, PCUR, PLAIL, PLAIH,  PWLMX  ,PFRTI)
 
+! (C) Copyright 2001- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !     ------------------------------------------------------------------
 !**   *SURFBC* - CREATES BOUNDARY CONDITIONS CHARACTERIZING THE SURFACE
 

--- a/ifs-source/surf/external/surfdeallo.F90
+++ b/ifs-source/surf/external/surfdeallo.F90
@@ -1,11 +1,12 @@
+SUBROUTINE SURFDEALLO(YDSURF)
+
 ! (C) Copyright 2001- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SURFDEALLO(YDSURF)
+! nor does it submit to any jurisdiction.
 
 !**** *SURFDEALLO * - Routine to deallocate space for global variables
 !                     from surface subroutine

--- a/ifs-source/surf/external/surfexcdriver.F90
+++ b/ifs-source/surf/external/surfexcdriver.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFEXCDRIVER    (YDSURF, CDCONF &
  & , KIDIA, KFDIA, KLON, KLEVS, KTILES, KVTYPES, KDIAG, KSTEP &
  & , KLEVSN, KLEVI, KDHVTLS, KDHFTLS, KDHVTSS, KDHFTSS &
@@ -59,7 +52,13 @@ USE ABORT_SURF_MOD
 USE SURFEXCDRIVER_CTL_MOD
 
 !endif INTERFACE
-
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !------------------------------------------------------------------------
 
 !  PURPOSE:

--- a/ifs-source/surf/external/surfexcdrivers.F90
+++ b/ifs-source/surf/external/surfexcdrivers.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFEXCDRIVERS    ( YDSURF, &
  &   KIDIA, KFDIA, KLON, KLEVS, KTILES, KSTEP &
  & , PTSTEP, PRVDIFTS &
@@ -42,6 +35,14 @@ USE ABORT_SURF_MOD
 USE SURFEXCDRIVERS_CTL_MOD
 
 !endif INTERFACE
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/external/surfpp.F90
+++ b/ifs-source/surf/external/surfpp.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFPP( YDSURF,KIDIA,KFDIA,KLON,KTILES, KDHVTLS, KDHFTLS &
  & , PTSTEP &
 ! input
@@ -36,6 +29,13 @@ USE SURFPP_CTL_MOD
 
 !endif INTERFACE
 
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !------------------------------------------------------------------------
 
 !  PURPOSE:

--- a/ifs-source/surf/external/surfpps.F90
+++ b/ifs-source/surf/external/surfpps.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFPPS( YDSURF,KIDIA,KFDIA,KLON,KTILES,LDPPCFLS &
  & , PTSTEP &
 ! input
@@ -30,6 +23,14 @@ USE ABORT_SURF_MOD
 USE SURFPPS_CTL_MOD
 
 !endif INTERFACE
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/external/surfrad.F90
+++ b/ifs-source/surf/external/surfrad.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1991- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFRAD(YDSURF,KDD,KMM,KMON,KSECO,&
  & KIDIA,KFDIA,KLON,KTILES,KSW,KLW,&
  & LDNH,&
@@ -29,6 +22,14 @@ USE ABORT_SURF_MOD
 USE SURFRAD_CTL_MOD
 
 !endif INTERFACE
+
+! (C) Copyright 1991- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFRAD - COMPUTES RADIATIVE PROPERTIES OF SURFACE
 

--- a/ifs-source/surf/external/surfseb.F90
+++ b/ifs-source/surf/external/surfseb.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFSEB   (YDSURF,KIDIA,KFDIA,KLON,KTILES,KTVL,KTVH,&
  & PTMST,PSSKM1M,PTSKM1M,PQSKM1M,PDQSDT,PRHOCHU,PRHOCQU,&
  & PALPHAL,PALPHAS,PSSRFL,PFRTI,PTSRF,PLAMSK,&
@@ -28,6 +21,14 @@ USE ABORT_SURF_MOD
 USE SURFSEB_CTL_MOD
 
 !endif INTERFACE
+
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/external/surfsebs.F90
+++ b/ifs-source/surf/external/surfsebs.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFSEBS   (YDSURF,KIDIA,KFDIA,KLON,KLEVSN,KTILES,KTVL,KTVH,&
  & PTMST,PSSKM1M,PTSKM1M,PQSKM1M,PDQSDT,PRHOCHU,PRHOCQU,&
  & PALPHAL,PALPHAS,PSSRFL,PFRTI,PTSRF,&
@@ -28,6 +21,14 @@ USE ABORT_SURF_MOD
 USE SURFSEBS_CTL_MOD
 
 !endif INTERFACE
+
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/external/surftstp.F90
+++ b/ifs-source/surf/external/surftstp.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFTSTP    (YDSURF, KIDIA , KFDIA , KLON  , KLEVS , KTILES,&
  & KLEVSN, KLEVO , KLEVI ,  KSTART , KSTEP,&
  & KDHVTSS , KDHFTSS,&
@@ -69,6 +62,14 @@ USE YOS_SURF, ONLY : TSURF, GET_SURF
 USE ABORT_SURF_MOD
 USE SURFTSTP_CTL_MOD
 !endif INTERFACE
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 !**** *SURFTSTP* - UPDATES LAND VALUES OF TEMPERATURE, MOISTURE AND SNOW.

--- a/ifs-source/surf/external/surftstps.F90
+++ b/ifs-source/surf/external/surftstps.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFTSTPS    (YDSURF , KIDIA , KFDIA , KLON  , KLEVS , KLEVSN, &
  & KTILES, KSOTY,&
  & PTSPHY , PSDOR, PFRTI,&
@@ -31,6 +24,14 @@ USE YOS_SURF, ONLY : TSURF, GET_SURF
 USE ABORT_SURF_MOD
 USE SURFTSTPS_CTL_MOD
 !endif INTERFACE
+
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 !**** *SURFTSTPS* - UPDATES LAND VALUES OF TEMPERATURE AND SNOW.

--- a/ifs-source/surf/external/surfws.F90
+++ b/ifs-source/surf/external/surfws.F90
@@ -1,15 +1,16 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURFWS    (YDSURF,KIDIA,KFDIA,KLON, KLEVS, KLEVSN, KTILES, PSDOR, &
                     & PLSM,    PFRTI, PMU0,                          &
                     & PTSAM1M, PTSKIN,PALBSN,                         &
                     & PTSNM1M, PSNM1M,                                &
                     & PRSNM1M, PWSNM1M                                )
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 !**   *SURFWS* - CREATES WARM START CONDITIONS FOR SURFACE VARIABLES

--- a/ifs-source/surf/external/susurf.F90
+++ b/ifs-source/surf/external/susurf.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2002- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUSURF(KSW,KCSS,KCSNEC,KSIL,KCOM,KTILES,KTSW,KLWEMISS,&
  & LD_LEFLAKE,LD_LEOCML,LD_LOCMLTKE,&       
  & LD_LWCOU, LD_LWCOU2W, LD_LWCOUHMF,&
@@ -29,6 +22,14 @@ USE ABORT_SURF_MOD
 USE SUSURF_CTL_MOD
 
 !endif INTERFACE
+
+! (C) Copyright 2002- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSURF* IS THE SET-UP ROUTINE FOR surface modules contain constants
 

--- a/ifs-source/surf/function/fcsttre.h
+++ b/ifs-source/surf/function/fcsttre.h
@@ -1,10 +1,10 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
 !*
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/function/fcsurf.h
+++ b/ifs-source/surf/function/fcsurf.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2016- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !     *FCSURF** CONTAINS STATEMENT FUNCTIONS USED BY THE SURFACE MODEL

--- a/ifs-source/surf/function/fcsvdfs.h
+++ b/ifs-source/surf/function/fcsvdfs.h
@@ -1,10 +1,10 @@
 ! (C) Copyright 1990- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/function/fcz0.h
+++ b/ifs-source/surf/function/fcz0.h
@@ -1,10 +1,10 @@
 ! (C) Copyright 2013- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/function/fcz0wn.h
+++ b/ifs-source/surf/function/fcz0wn.h
@@ -1,10 +1,10 @@
 ! (C) Copyright 2018- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surf_inq.h
+++ b/ifs-source/surf/interface/surf_inq.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2001- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURF_INQ(YDSURF,&
                   & KNVTYPES,KNSOTY,PRRCSOIL,PRWSAT,PRWCAP,PRWPWP,PRQWEVAP,PRQWSBCR,&
@@ -17,6 +10,13 @@ SUBROUTINE SURF_INQ(YDSURF,&
                   & LD_LESNML, RLEVSNMIN, RLEVSNMAX,&
                   & RLEVSNMIN_GL, RLEVSNMAX_GL )
 
+! (C) Copyright 2001- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**   *SURF_INQ*  Extract information from the surface package
 
 !     Purpose.

--- a/ifs-source/surf/interface/surfbc.h
+++ b/ifs-source/surf/interface/surfbc.h
@@ -1,10 +1,3 @@
-! (C) Copyright 1999- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFBC    (YDSURF,KIDIA,KFDIA,KLON,KTILES,KLEVSN,&
  & PTVL   , PCO2TYP,PTVH   ,PSOTY  ,PSDOR,PCVLC  ,PCVHC, PCURC, &
@@ -15,6 +8,13 @@ SUBROUTINE SURFBC    (YDSURF,KIDIA,KFDIA,KLON,KTILES,KLEVSN,&
  & KTVL   ,KCO2TYP, KTVH   ,KSOTY,&
  & PCVL   ,PCVH, PCUR,PLAIL, PLAIH,  PWLMX  ,PFRTI)
 
+! (C) Copyright 1999- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !     ------------------------------------------------------------------
 !**   *SURFBC* - CREATES BOUNDARY CONDITIONS CHARACTERIZING THE SURFACE
 

--- a/ifs-source/surf/interface/surfexcdriver.h
+++ b/ifs-source/surf/interface/surfexcdriver.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFEXCDRIVER    (YDSURF, CDCONF &
  & , KIDIA, KFDIA, KLON, KLEVS, KTILES, KVTYPES, KDIAG, KSTEP &
@@ -50,6 +43,14 @@ SUBROUTINE SURFEXCDRIVER    (YDSURF, CDCONF &
 USE PARKIND1, ONLY : JPIM, JPRB
 USE ISO_C_BINDING
 
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surfexcdrivers.h
+++ b/ifs-source/surf/interface/surfexcdrivers.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFEXCDRIVERS    ( YDSURF, &
  &   KIDIA, KFDIA, KLON, KLEVS, KTILES, KSTEP &
@@ -33,6 +26,14 @@ SUBROUTINE SURFEXCDRIVERS    ( YDSURF, &
 
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surfpp.h
+++ b/ifs-source/surf/interface/surfpp.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFPP( YDSURF,KIDIA,KFDIA,KLON,KTILES, KDHVTLS, KDHFTLS &
  & , PTSTEP &
@@ -26,6 +19,14 @@ SUBROUTINE SURFPP( YDSURF,KIDIA,KFDIA,KLON,KTILES, KDHVTLS, KDHFTLS &
 
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surfpps.h
+++ b/ifs-source/surf/interface/surfpps.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFPPS( YDSURF, KIDIA,KFDIA,KLON,KTILES,LDPPCFLS &
  & , PTSTEP &
@@ -21,6 +14,14 @@ SUBROUTINE SURFPPS( YDSURF, KIDIA,KFDIA,KLON,KTILES,LDPPCFLS &
 
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surfrad.h
+++ b/ifs-source/surf/interface/surfrad.h
@@ -1,10 +1,3 @@
-! (C) Copyright 1991- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFRAD    (YDSURF,KDD,KMM,KMON,KSECO,&
  & KIDIA,KFDIA,KLON,KTILES,KSW,KLW,&
@@ -20,6 +13,14 @@ SUBROUTINE SURFRAD    (YDSURF,KDD,KMM,KMON,KSECO,&
 
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
+
+! (C) Copyright 1991- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFRAD - COMPUTES RADIATIVE PROPERTIES OF SURFACE
 

--- a/ifs-source/surf/interface/surfseb.h
+++ b/ifs-source/surf/interface/surfseb.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFSEB   (YDSURF,KIDIA,KFDIA,KLON,KTILES,KTVL,KTVH,&
  & PTMST,PSSKM1M,PTSKM1M,PQSKM1M,PDQSDT,PRHOCHU,PRHOCQU,&
@@ -20,6 +13,13 @@ SUBROUTINE SURFSEB   (YDSURF,KIDIA,KFDIA,KLON,KTILES,KTVL,KTVH,&
 USE PARKIND1, ONLY : JPIM, JPRB
 USE ISO_C_BINDING
 
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surfsebs.h
+++ b/ifs-source/surf/interface/surfsebs.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFSEBS   (YDSURF,KIDIA,KFDIA,KLON,KLEVSN,KTILES,KTVL,KTVH,&
  & PTMST,PSSKM1M,PTSKM1M,PQSKM1M,PDQSDT,PRHOCHU,PRHOCQU,&
@@ -19,6 +12,14 @@ SUBROUTINE SURFSEBS   (YDSURF,KIDIA,KFDIA,KLON,KLEVSN,KTILES,KTVL,KTVH,&
 
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
+
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/interface/surftstp.h
+++ b/ifs-source/surf/interface/surftstp.h
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFTSTP    (YDSURF, KIDIA , KFDIA , KLON  , KLEVS , KTILES,&
  & KLEVSN, KLEVO , KLEVI ,  KSTART , KSTEP,&
@@ -62,6 +55,13 @@ SUBROUTINE SURFTSTP    (YDSURF, KIDIA , KFDIA , KLON  , KLEVS , KTILES,&
 USE PARKIND1, ONLY : JPIM, JPRB
 USE ISO_C_BINDING
 
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 !**** *SURFTSTP* - UPDATES LAND VALUES OF TEMPERATURE, MOISTURE AND SNOW.

--- a/ifs-source/surf/interface/surftstps.h
+++ b/ifs-source/surf/interface/surftstps.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFTSTPS    (YDSURF , KIDIA , KFDIA , KLON  , KLEVS , KLEVSN,& 
  & KTILES, KSOTY,&
@@ -23,6 +16,14 @@ SUBROUTINE SURFTSTPS    (YDSURF , KIDIA , KFDIA , KLON  , KLEVS , KLEVSN,&
 
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**** *SURFTSTPS* - UPDATES LAND VALUES OF TEMPERATURE AND SNOW.

--- a/ifs-source/surf/interface/surfws.h
+++ b/ifs-source/surf/interface/surfws.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SURFWS    (YDSURF,KIDIA,KFDIA,KLON,KLEVS,KLEVSN, KTILES,&
                     & PSDOR, &
@@ -12,6 +5,14 @@ SUBROUTINE SURFWS    (YDSURF,KIDIA,KFDIA,KLON,KLEVS,KLEVSN, KTILES,&
                     & PTSAM1M,PTSKIN, PALBSN,                      &  
                     & PTSNM1M ,PSNM1M ,                            &
                     & PRSNM1M, PWSNM1M                              )
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 !**   *SURFWS* - CREATES WARM START CONDITIONS FOR SURFACE VARIABLES

--- a/ifs-source/surf/interface/susurf.h
+++ b/ifs-source/surf/interface/susurf.h
@@ -1,10 +1,3 @@
-! (C) Copyright 2002- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 INTERFACE
 SUBROUTINE SUSURF(KSW,KCSS,KCSNEC,KSIL,KCOM,KTILES,KTSW,KLWEMISS,&
  & LD_LEFLAKE,LD_LEOCML,LD_LOCMLTKE,&       
@@ -22,6 +15,13 @@ SUBROUTINE SUSURF(KSW,KCSS,KCSNEC,KSIL,KCOM,KTILES,KTSW,KLWEMISS,&
 USE PARKIND1, ONLY : JPIM, JPRB
 USE, INTRINSIC :: ISO_C_BINDING
 
+! (C) Copyright 2002- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSURF* IS THE SET-UP ROUTINE FOR surface modules contain constants
 

--- a/ifs-source/surf/module/abort_surf_mod.F90
+++ b/ifs-source/surf/module/abort_surf_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE ABORT_SURF_MOD
 CONTAINS
 SUBROUTINE ABORT_SURF(CDTEXT)
@@ -13,6 +6,14 @@ USE PARKIND1  ,ONLY : JPIM     ,JPRB
 USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK, JPHOOK
 
 USE MPL_MODULE
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/canalb_mod.F90
+++ b/ifs-source/surf/module/canalb_mod.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2010- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE CANALB_MOD
 CONTAINS
 SUBROUTINE CANALB(KIDIA,KFDIA,YDURB,PMU0,PCANALB)
+
+    ! (C) Copyright 2010- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     PURPOSE
 !     -------

--- a/ifs-source/surf/module/ccetr_mod.F90
+++ b/ifs-source/surf/module/ccetr_mod.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 1998- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE CCETR_MOD
 CONTAINS
 SUBROUTINE CCETR(KIDIA,KFDIA,KLON,KVTYPE,LDLAND,PIA,PMU0,PABC,PLAI,YDAGS,PXIA)
+
+! (C) Copyright 1998- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**  *CCETR* 
 

--- a/ifs-source/surf/module/cotwo_mod.F90
+++ b/ifs-source/surf/module/cotwo_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1997- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE COTWO_MOD
 
 CONTAINS
@@ -13,6 +6,13 @@ SUBROUTINE COTWO(KIDIA,KFDIA,KLON,LDLAND, PAN, PAG, PRD, PGS, PGC, PCSP, &
  & PFZERO, PGMEST, PEPSO, PAMMAX  )
 
 !***
+! (C) Copyright 1997- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *COTWO* - CALCULATES NET ASSIMILATION OF CO2 AND LEAF CONDUCTANCE
 

--- a/ifs-source/surf/module/cotworestress_mod.F90
+++ b/ifs-source/surf/module/cotworestress_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1997- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE COTWORESTRESS_MOD
 CONTAINS
 SUBROUTINE COTWORESTRESS(KIDIA,KFDIA,KLON,KVTYPE,KCO2TYP,PFRTI,&
@@ -17,6 +10,13 @@ SUBROUTINE COTWORESTRESS(KIDIA,KFDIA,KLON,KVTYPE,KCO2TYP,PFRTI,&
      & PAN, PAG,PRD, &
      & PWET,PDSP,PDMAXT)
 
+! (C) Copyright 1997- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
   !**   *COTWORESTRESS* - CALCULATES NET ASSIMILATION OF CO2 AND CANOPY CONDUCTANCE  
 
   !     A. Boone       * Meteo-France *     27/10/97 

--- a/ifs-source/surf/module/cptave_mod.F90
+++ b/ifs-source/surf/module/cptave_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE CPTAVE_MOD
 CONTAINS
 SUBROUTINE CPTAVE(PTHESAT,PTHECAP,PTHEPWP,PCKSAT,PSISAT,PB)
@@ -14,6 +7,13 @@ USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK, JPHOOK
 
 USE YOS_DIM   , ONLY : JPSOILTY, JPTEXT
 
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !     Purpose.
 !     --------
 !**** *CPTAVE * - COMPUTES AVERAGE SOIL PROPERTIES 

--- a/ifs-source/surf/module/farquhar_mod.F90
+++ b/ifs-source/surf/module/farquhar_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE FARQUHAR_MOD
 
   USE PARKIND1, ONLY : JPIM, JPRB, JPRM, JPRD
@@ -15,6 +8,13 @@ MODULE FARQUHAR_MOD
   USE YOS_CST,  ONLY : TCST
 
   USE SUFARQUHAR_MOD
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
   IMPLICIT NONE
 

--- a/ifs-source/surf/module/flake_driver_mod.F90
+++ b/ifs-source/surf/module/flake_driver_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 ! File %M% from Library %Q%
 ! Version %I% from %G% extracted: %H%
 !------------------------------------------------------------------------------
@@ -25,6 +18,13 @@ SUBROUTINE FLAKE_DRIVER( KIDIA, KFDIA, KLON,         &
                   
                   
 
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !------------------------------------------------------------------------------
 !
 ! Description:

--- a/ifs-source/surf/module/flakeene_mod.F90
+++ b/ifs-source/surf/module/flakeene_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE FLAKEENE_MOD
 CONTAINS
 SUBROUTINE FLAKEENE                                                      &
@@ -21,6 +14,13 @@ SUBROUTINE FLAKEENE                                                      &
   &   PT_BOT_N_FLK    , PH_ICE_N_FLK      , PH_ML_N_FLK           ,      &
   &   PC_T_N_FLK      , PT_SFC_N                                         )         
 
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !------------------------------------------------------------------------------
 !
 ! Description:

--- a/ifs-source/surf/module/flakerad_mod.F90
+++ b/ifs-source/surf/module/flakerad_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE FLAKERAD_MOD
 CONTAINS
 SUBROUTINE FLAKERAD&
@@ -16,6 +9,13 @@ SUBROUTINE FLAKERAD&
   &  PI_ICE_FLK   , PI_BOT_FLK      , PI_W_FLK        ,  &
   &  PI_H_FLK     , PI_INTM_0_H_FLK , PI_INTM_H_D_FLK    )
 
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !------------------------------------------------------------------------------
 !
 ! Description:

--- a/ifs-source/surf/module/kpp_abk80_mod.F90
+++ b/ifs-source/surf/module/kpp_abk80_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1987- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_ABK80_MOD
 CONTAINS
 SUBROUTINE KPP_ABK80 &
@@ -12,6 +5,13 @@ SUBROUTINE KPP_ABK80 &
   &   PSAL     ,PTEMP    ,PRES     ,PALPHA   ,PBETA    ,&
   &   PSIG0    ,PSIG     ,PRHO0    ,LDALPHA  ,LDBETA   ) 
 
+! (C) Copyright 1987- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 ! Subroutine to coordinate computation of the expansion coefficients  

--- a/ifs-source/surf/module/kpp_bldepth_mod.F90
+++ b/ifs-source/surf/module/kpp_bldepth_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_BLDEPTH_MOD
 CONTAINS 
 SUBROUTINE KPP_BLDEPTH &
@@ -15,6 +8,13 @@ SUBROUTINE KPP_BLDEPTH &
   &   PSTABLE  ,PCASEA   ,KBL      ,PSIGMA   ,PWM      ,&
   &   PWS      ,POCDEPTH ,YDOCEAN_ML )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine calculates boundary layer depth.

--- a/ifs-source/surf/module/kpp_blmix_mod.F90
+++ b/ifs-source/surf/module/kpp_blmix_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_BLMIX_MOD
 CONTAINS
 SUBROUTINE KPP_BLMIX &
@@ -14,6 +7,13 @@ SUBROUTINE KPP_BLMIX &
   &   PDIFS    ,PDIFT    ,KBL      ,PGHAT    ,PSIGMA   ,&
   &   PWM      ,PWS      ,YDOCEAN_ML)
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine sets computes mixing coefficients within boundary 

--- a/ifs-source/surf/module/kpp_cpsw_mod.F90
+++ b/ifs-source/surf/module/kpp_cpsw_mod.F90
@@ -1,16 +1,16 @@
-! (C) Copyright 2008- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_CPSW_MOD
 CONTAINS
 SUBROUTINE KPP_CPSW &
   & ( KIDIA    ,KFDIA    ,KLON     ,KLEV     ,LDKPPCAL ,&
   &   PS       ,PT1      ,P0       ,PCPSW    )
 
+! (C) Copyright 2008- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 ! Compute Specific heat

--- a/ifs-source/surf/module/kpp_interior_mix_mod.F90
+++ b/ifs-source/surf/module/kpp_interior_mix_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_INTERIOR_MIX_MOD
 CONTAINS
 SUBROUTINE KPP_INTERIOR_MIX &
@@ -13,6 +6,13 @@ SUBROUTINE KPP_INTERIOR_MIX &
   &   PALPHADT ,PBETADS  ,YDOCEAN_ML, &
   &   PDIFM    ,PDIFS    ,PDIFT    )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine calculates interior viscosity/diffusivity 

--- a/ifs-source/surf/module/kpp_kppmix_mod.F90
+++ b/ifs-source/surf/module/kpp_kppmix_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_KPPMIX_MOD
 CONTAINS
 SUBROUTINE KPP_KPPMIX &
@@ -18,6 +11,13 @@ SUBROUTINE KPP_KPPMIX &
   &   PSWDK_SAVE, PTALPHA ,PSBETA  ,POCDEPTH ,PRHOH2O  ,&
   &   PRHO_INV ,YDCST    ,YDOCEAN_ML )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine computes coefficients for vertical mixing.

--- a/ifs-source/surf/module/kpp_ocnint_mod.F90
+++ b/ifs-source/surf/module/kpp_ocnint_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_OCNINT_MOD
 CONTAINS
 SUBROUTINE KPP_OCNINT &
@@ -15,6 +8,13 @@ SUBROUTINE KPP_OCNINT &
   &   PDIFS    ,PGHAT    ,PADV     ,PUN      ,PXN      ,&
   &   PWX      ,PWXNT    ,PWU      ,PDTO     ,YDOCEAN_ML )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine calculates time integration of the ocean model.

--- a/ifs-source/surf/module/kpp_swfrac_mod.F90
+++ b/ifs-source/surf/module/kpp_swfrac_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_SWFRAC_MOD
 CONTAINS
 SUBROUTINE KPP_SWFRAC &
@@ -12,6 +5,13 @@ SUBROUTINE KPP_SWFRAC &
   &   LDINIT_KPP,LDKPPCAL,PFACT    ,PDO      ,PSWDK_SAVE,&
   &   PSWDK    ,YDOCEAN_ML)
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine computes fraction of solar short-wave flux penetrating 

--- a/ifs-source/surf/module/kpp_tridcof_mod.F90
+++ b/ifs-source/surf/module/kpp_tridcof_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_TRIDCOF_MOD
 CONTAINS
 SUBROUTINE KPP_TRIDCOF &
@@ -12,6 +5,13 @@ SUBROUTINE KPP_TRIDCOF &
   &   PDIFF    ,PTRI0    ,PTRI1    ,PCU      ,PCC      ,&
   &   PCL      )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine sets coefficients for tridiagonal matrix. 

--- a/ifs-source/surf/module/kpp_tridmat_mod.F90
+++ b/ifs-source/surf/module/kpp_tridmat_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_TRIDMAT_MOD
 CONTAINS
 SUBROUTINE KPP_TRIDMAT &
@@ -13,6 +6,13 @@ SUBROUTINE KPP_TRIDMAT &
   &   PYO      ,YDOCEAN_ML,&
   &   PYN )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine solves tridiagonal matrix with Thomas algorithm.

--- a/ifs-source/surf/module/kpp_tridrhs_mod.F90
+++ b/ifs-source/surf/module/kpp_tridrhs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_TRIDRHS_MOD
 CONTAINS
 SUBROUTINE KPP_TRIDRHS &
@@ -14,6 +7,13 @@ SUBROUTINE KPP_TRIDRHS &
   &   PGHATFLUX,PRHS     ,PDTO     ,PADV     ,PRHO     ,&
   &   PCP      ,KSCLR    ,YDOCEAN_ML )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine computes right hand side of tridiagonal matrix 

--- a/ifs-source/surf/module/kpp_wscale_mod.F90
+++ b/ifs-source/surf/module/kpp_wscale_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE KPP_WSCALE_MOD
 CONTAINS
 SUBROUTINE KPP_WSCALE &
@@ -12,6 +5,13 @@ SUBROUTINE KPP_WSCALE &
  &   PHBL     ,PUSTAR   ,PBFSFC   ,PWM      ,PWS      ,&
  &   YDOCEAN_ML )
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! Purpose :
 ! -------
 !   This routine compute turbulent velocity scales.

--- a/ifs-source/surf/module/nitro_decline_mod.F90
+++ b/ifs-source/surf/module/nitro_decline_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE NITRO_DECLINE_MOD
 CONTAINS
 SUBROUTINE NITRO_DECLINE(KIDIA,KFDIA,KVT,KLON,KSTEP, PTSPHY,&
@@ -15,6 +8,13 @@ SUBROUTINE NITRO_DECLINE(KIDIA,KFDIA,KVT,KLON,KSTEP, PTSPHY,&
  & PBIOMASS_LAST,PBIOMASSTR_LAST,PBIOMASSTR2_LAST,&
  & PBIOMASS,PBLOSS)
 
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**  *NITRO_DECLINE* 
 
 !     PURPOSE

--- a/ifs-source/surf/module/oc_mlm_mod.F90
+++ b/ifs-source/surf/module/oc_mlm_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE OC_MLM_MOD
 
 CONTAINS
@@ -14,6 +7,14 @@ SUBROUTINE OC_MLM(KIDIA,KFDIA,KLON,KLEVO,DELT,NSTEP,RT,Q_0,FC,&
  &                PUSTOKES ,PVSTOKES ,&
  &                XKS,U_S,V_S,T_S,&
  &                POTKE,U,V,T,YDMLM,YDCST)
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !
 !***  DETERMINES EVOLUTION OF U, V AND T USING A MIXED LAYER MODEL 
 !     FOR THE UPPER OCEAN

--- a/ifs-source/surf/module/ocean_ml_driver_mod.F90
+++ b/ifs-source/surf/module/ocean_ml_driver_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1994- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE OCEAN_ML_DRIVER_MOD
 
 CONTAINS
@@ -22,6 +15,13 @@ SUBROUTINE OCEAN_ML_DRIVER &
  &   YDCST    ,YDOCEAN_ML)
 
 
+! (C) Copyright 1994- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! -------
 !   This routine is the main driver for the ocean mixed layer model (KPP).
 

--- a/ifs-source/surf/module/ocean_ml_driver_v2_mod.F90
+++ b/ifs-source/surf/module/ocean_ml_driver_v2_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE OCEAN_ML_DRIVER_V2_MOD
 
 CONTAINS
@@ -18,6 +11,13 @@ SUBROUTINE OCEAN_ML_DRIVER_V2 &
  &   YDCST    ,YDEXC    ,YDMLM    ,&
  &   POTKE    ,PUOE1    ,PVOE1    ,PTOE1    ,PSOE1    )
 !
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 ! -------
 !   THIS ROUTINE IS THE MAIN DRIVER FOR THE OCEAN MIXED LAYER MODEL.
 

--- a/ifs-source/surf/module/source_e_mod.F90
+++ b/ifs-source/surf/module/source_e_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2010- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SOURCE_E_MOD
 
 CONTAINS
@@ -15,6 +8,13 @@ SUBROUTINE SOURCE_E(KIDIA,KFDIA,KLON,Z,T,&
  &                  D_H,D_E,&
  &                  YDMLM, YDCST)
 !
+! (C) Copyright 2010- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !***  DETERMINES TKE SOURCE FUNCTION AND DIFFUSION COEFFICIENTS
 !
 !

--- a/ifs-source/surf/module/sppcfl_mod.F90
+++ b/ifs-source/surf/module/sppcfl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SPPCFL_MOD
 CONTAINS
 SUBROUTINE SPPCFL(KIDIA, KFDIA, KLON &
@@ -23,6 +16,13 @@ USE YOS_EXCS  , ONLY : RCHBCD, RCHBBCD, RCHBB, RCHBD, RCHBA, RCHBHDL, &
 USE YOS_CST   , ONLY : TCST
 USE YOS_EXC    ,ONLY : TEXC
 
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !     ------------------------------------------------------------------
 
 !**   *SPPCFL* - COMPUTES THE SURFACE (2 M) TEMPERATURE AND HUMIDITY

--- a/ifs-source/surf/module/sppcfls_mod.F90
+++ b/ifs-source/surf/module/sppcfls_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SPPCFLS_MOD
 CONTAINS
 SUBROUTINE SPPCFLS(KIDIA,KFDIA,KLON,&
@@ -20,6 +13,13 @@ USE YOS_THF   , ONLY : R4LES, R2ES, R3LES, RVTMP2
 USE YOS_CST   , ONLY : TCST
 USE YOS_EXC   , ONLY : TEXC
 
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !     ------------------------------------------------------------------
 
 !**   *SPPCFLS* - COMPUTES THE SURFACE (2 M) TEMPERATURE AND HUMIDITY

--- a/ifs-source/surf/module/sppgust_mod.F90
+++ b/ifs-source/surf/module/sppgust_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SPPGUST_MOD
 CONTAINS
 SUBROUTINE SPPGUST(KIDIA, KFDIA, KLON &
@@ -19,6 +12,14 @@ USE YOS_EXCS , ONLY : RCHBCD, RCHBBCD, RCHBB, RCHBD, RCHBA, RCHBHDL, &
  & RCDHALF, RCHETB, RCHB23A, RCHETA, RCDHPI2
 USE YOS_CST  , ONLY : TCST
 USE YOS_EXC  , ONLY : TEXC
+
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/srfcotwo_mod.F90
+++ b/ifs-source/surf/module/srfcotwo_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFCOTWO_MOD
 CONTAINS
 SUBROUTINE SRFCOTWO(KIDIA,KFDIA,KLON,KLEVS,KTILES,&
@@ -19,6 +12,14 @@ SUBROUTINE SRFCOTWO(KIDIA,KFDIA,KLON,KLEVS,KTILES,&
  & PANDAYVT,PANFMVT,&
  & PAG,PRD,PAN,PRSOIL_STR,PRECO,PCO2FLUX,PCH4FLUX,&
  & PDHCO2S)
+
+ ! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
  !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/srfene_mod.F90
+++ b/ifs-source/surf/module/srfene_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1996- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFENE_MOD
 CONTAINS
 SUBROUTINE SRFENE(&
@@ -13,6 +6,14 @@ SUBROUTINE SRFENE(&
  & PTSAM1M, KSOTY, PCVL , PCVH ,&
  & YDCST  , YDSOIL ,&
  & PENES)  
+
+! (C) Copyright 1996- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFENE* - COMPUTES SOIL ENERGY FOR EACH LAYER.
 

--- a/ifs-source/surf/module/srfi_mod.F90
+++ b/ifs-source/surf/module/srfi_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1999- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFI_MOD
 CONTAINS
 SUBROUTINE SRFI(KIDIA  , KFDIA  , KLON , KLEVS  , KLEVI  , &
@@ -19,6 +12,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE SRFWDIF_MOD
+
+! (C) Copyright 1999- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFI* - Computes temperature changes in soil.
 

--- a/ifs-source/surf/module/srfis_mod.F90
+++ b/ifs-source/surf/module/srfis_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFIS_MOD
 CONTAINS
 SUBROUTINE SRFIS(KIDIA , KFDIA  , KLON  , KLEVS ,&
@@ -20,6 +13,14 @@ USE YOS_SOIL  , ONLY : TSOIL
 USE SRFWDIFS_MOD
 
 #ifdef DOC
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFIS* - Computes temperature changes in soil.
 
 !     PURPOSE.

--- a/ifs-source/surf/module/srfrcg_mod.F90
+++ b/ifs-source/surf/module/srfrcg_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFRCG_MOD
 CONTAINS
 SUBROUTINE SRFRCG(KIDIA  , KFDIA  , KLON , KTILES, KLEVS ,&
@@ -19,6 +12,14 @@ USE YOS_THF   , ONLY : RHOH2O
 USE YOS_CST   , ONLY : TCST
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_URB   , ONLY : TURB
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFT* - COMPUTES SOIL VOLUMETRIC HEAT CAPACITY.
 !     PURPOSE.

--- a/ifs-source/surf/module/srfrcgs_mod.F90
+++ b/ifs-source/surf/module/srfrcgs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFRCGS_MOD
 CONTAINS
 SUBROUTINE SRFRCGS(KIDIA  , KFDIA  , KLON , KLEVS ,&
@@ -19,6 +12,14 @@ USE YOS_CST   , ONLY : TCST
 USE YOS_SOIL  , ONLY : TSOIL
 
 #ifdef DOC
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFRCGS* - COMPUTES SOIL VOLUMETRIC HEAT CAPACITY.
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfrootfr_mod.F90
+++ b/ifs-source/surf/module/srfrootfr_mod.F90
@@ -1,16 +1,17 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFROOTFR_MOD
 CONTAINS
 SUBROUTINE SRFROOTFR(KLEVS,KVTYPES,PSDEPTH,PROOTF)
  
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 USE YOMHOOK   ,ONLY : LHOOK,   DR_HOOK, JPHOOK
+
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFROOTFR* - Initializing root fraction
 

--- a/ifs-source/surf/module/srfsn_asn_mod.F90
+++ b/ifs-source/surf/module/srfsn_asn_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_ASN_MOD
 CONTAINS
 SUBROUTINE SRFSN_ASN(KIDIA,KFDIA,KLON,PTMST,LLNOSNOW,PASNM1M,&
@@ -16,6 +9,14 @@ USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 
 USE YOS_SOIL , ONLY : TSOIL 
 USE YOS_CST  , ONLY : TCST
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFSN_RSN* - Snow albedo
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfsn_driver_mod.F90
+++ b/ifs-source/surf/module/srfsn_driver_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_DRIVER_MOD
 CONTAINS
 SUBROUTINE SRFSN_DRIVER(KIDIA   ,KFDIA   ,KLON   ,KLEVSN, PTMST, LDLAND,&
@@ -41,6 +34,14 @@ USE SRFSN_REGRID_MOD
 USE SRFSN_SSRABS_MOD
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFSN_DRIVER* - Snow scheme driver 
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_lwexp_mod.F90
+++ b/ifs-source/surf/module/srfsn_lwexp_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1999- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_LWEXP_MOD
 CONTAINS
 SUBROUTINE SRFSN_LWEXP(KIDIA  , KFDIA  , KLON   ,PTMST  ,&
@@ -25,6 +18,13 @@ USE YOS_VEG   , ONLY : TVEG
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_FLAKE , ONLY : TFLAKE
 
+! (C) Copyright 1999- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSN* - CONTAINS SNOW PARAMETRIZATION 
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfsn_lwimp_mod.F90
+++ b/ifs-source/surf/module/srfsn_lwimp_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1999- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_LWIMP_MOD
 CONTAINS
 SUBROUTINE SRFSN_LWIMP(KIDIA  ,KFDIA  ,KLON   ,KTILES   ,PTMST,LDLAND,  &
@@ -26,6 +19,13 @@ USE YOS_SOIL , ONLY : TSOIL
 USE YOS_FLAKE, ONLY : TFLAKE
 USE YOS_EXC  , ONLY : TEXC
 
+! (C) Copyright 1999- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSN_LWIMP* - CONTAINS SNOW PARAMETRIZATION 
 !
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_lwimpmls_mod.F90
+++ b/ifs-source/surf/module/srfsn_lwimpmls_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_LWIMPMLS_MOD
 CONTAINS
 SUBROUTINE SRFSN_LWIMPMLS(KIDIA  ,KFDIA  ,KLON   ,PTMST,        &
@@ -25,6 +18,13 @@ USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_FLAKE , ONLY : TFLAKE
 
 #ifdef DOC
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSNS_LWIMP* - CONTAINS SNOW PARAMETRIZATION
 !
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_lwimps_mod.F90
+++ b/ifs-source/surf/module/srfsn_lwimps_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_LWIMPS_MOD
 CONTAINS
 SUBROUTINE SRFSN_LWIMPS(KIDIA  ,KFDIA  ,KLON   ,PTMST,        &
@@ -24,6 +17,13 @@ USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_FLAKE , ONLY : TFLAKE
 
 #ifdef DOC
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSNS_LWIMP* - CONTAINS SNOW PARAMETRIZATION
 !
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_mod.F90
+++ b/ifs-source/surf/module/srfsn_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1999- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_MOD
 CONTAINS
 SUBROUTINE SRFSN(KIDIA       , KFDIA  , KLON   , KTILES  , PTMST, &
@@ -23,6 +16,13 @@ USE YOS_VEG  , ONLY : TVEG
 USE YOS_SOIL , ONLY : TSOIL
 USE YOS_FLAKE, ONLY : TFLAKE
 
+! (C) Copyright 1999- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSN* - CONTAINS SNOW PARAMETRIZATION 
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfsn_regrid_mod.F90
+++ b/ifs-source/surf/module/srfsn_regrid_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_REGRID_MOD
 CONTAINS
 SUBROUTINE SRFSN_REGRID(KIDIA,KFDIA,KLON,KLEVSN,LLNOSNOW,&
@@ -15,6 +8,13 @@ USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE ABORT_SURF_MOD
 
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSN_REGRID* - Snow vertical re-grid
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfsn_rsn_mod.F90
+++ b/ifs-source/surf/module/srfsn_rsn_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_RSN_MOD
 CONTAINS
 SUBROUTINE SRFSN_RSN(KIDIA,KFDIA,KLON,KLEVSN,PTMST,LLNOSNOW,&
@@ -19,6 +12,13 @@ USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_SOIL , ONLY : TSOIL 
 USE YOS_CST  , ONLY : TCST
 
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !**** *SRFSN_RSN* - Snow density
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfsn_ssrabs_mod.F90
+++ b/ifs-source/surf/module/srfsn_ssrabs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_SSRABS_MOD
 CONTAINS
 SUBROUTINE SRFSN_SSRABS(KIDIA,KFDIA,KLON,KLEVSN,&
@@ -21,6 +14,14 @@ USE YOS_SOIL , ONLY : TSOIL
 USE YOS_CST  , ONLY : TCST
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFSN_SSRABS* - Shortwave radiation absorption by snow
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_ssrabss_mod.F90
+++ b/ifs-source/surf/module/srfsn_ssrabss_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2020- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_SSRABSS_MOD
 CONTAINS
 SUBROUTINE SRFSN_SSRABSS(KIDIA,KFDIA,KLON,KLEVSN,&
@@ -21,6 +14,14 @@ USE YOS_SOIL , ONLY : TSOIL
 USE YOS_CST  , ONLY : TCST
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2020- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFSN_SSRABSS* - Shortwave radiation absorption by snow (simplified)
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_vgrid_mod.F90
+++ b/ifs-source/surf/module/srfsn_vgrid_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_VGRID_MOD
 CONTAINS
 SUBROUTINE SRFSN_VGRID(KIDIA, KFDIA, KLON, KLEVSN,LLNOSNOW,PSDOR,&
@@ -17,6 +10,14 @@ USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFSN_VGRID* - Define snow verical grid 
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_webal_mod.F90
+++ b/ifs-source/surf/module/srfsn_webal_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2015- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_WEBAL_MOD
 CONTAINS
 SUBROUTINE SRFSN_WEBAL(KIDIA,KFDIA,KLON,KLEVSN,&
@@ -22,6 +15,14 @@ USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_SOIL , ONLY : TSOIL 
 USE YOS_CST  , ONLY : TCST
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2015- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFSN_WEBAL* - Snow water & energy balance 
 !     PURPOSE.

--- a/ifs-source/surf/module/srfsn_webals_mod.F90
+++ b/ifs-source/surf/module/srfsn_webals_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2021- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFSN_WEBALS_MOD
 CONTAINS
 SUBROUTINE SRFSN_WEBALS(KIDIA,KFDIA,KLON,KLEVSN,&
@@ -27,6 +20,14 @@ USE YOS_SOIL , ONLY : TSOIL
 USE YOS_CST  , ONLY : TCST
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2021- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFSN_WEBALS* - Snow simplified energy balance 
 !     PURPOSE.

--- a/ifs-source/surf/module/srft_mod.F90
+++ b/ifs-source/surf/module/srft_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFT_MOD
 CONTAINS
 SUBROUTINE SRFT(KIDIA  , KFDIA , KLON   , KTILES, KLEVS ,&
@@ -23,6 +16,14 @@ USE YOS_FLAKE, ONLY : TFLAKE
 USE YOS_URB  , ONLY : TURB
 
 USE SRFWDIF_MOD
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFT* - Computes temperature changes in soil.
 

--- a/ifs-source/surf/module/srfts_mod.F90
+++ b/ifs-source/surf/module/srfts_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFTS_MOD
 CONTAINS
 SUBROUTINE SRFTS(KIDIA  , KFDIA  , KLON   , KLEVS ,&
@@ -23,6 +16,14 @@ USE YOS_FLAKE , ONLY : TFLAKE
 USE SRFWDIFS_MOD
 
 #ifdef DOC
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFTS* - Computes temperature changes in soil.
 
 !     PURPOSE.

--- a/ifs-source/surf/module/srfvegevol_mod.F90
+++ b/ifs-source/surf/module/srfvegevol_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFVEGEVOL_MOD
 CONTAINS
 SUBROUTINE SRFVEGEVOL(KIDIA,KFDIA,KLON,KLEVS,KSTEP, &
@@ -21,6 +14,14 @@ SUBROUTINE SRFVEGEVOL(KIDIA,KFDIA,KLON,KLEVS,KSTEP, &
  & PDHBIOS,PDHVEGS, &
  & YDCST,YDVEG,YDAGS)
 
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**  *SRFVEG_EVOL*  CALLED BY *SURFTSTP_CTL*
 

--- a/ifs-source/surf/module/srfwdif_mod.F90
+++ b/ifs-source/surf/module/srfwdif_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWDIF_MOD
 CONTAINS
 SUBROUTINE SRFWDIF(KIDIA,KFDIA,KLON,KLEVS,&
@@ -15,6 +8,14 @@ SUBROUTINE SRFWDIF(KIDIA,KFDIA,KLON,KLEVS,&
 USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_SOIL , ONLY : TSOIL
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFWDIF* -  DOES THE IMPLICIT CALCULATION FOR SOIL MOISTURE
 

--- a/ifs-source/surf/module/srfwdifs_mod.F90
+++ b/ifs-source/surf/module/srfwdifs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWDIFS_MOD
 CONTAINS
 SUBROUTINE SRFWDIFS(KIDIA,KFDIA,KLON,KLEVS,&
@@ -16,6 +9,14 @@ USE YOMHOOK   , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_SOIL  , ONLY : TSOIL
 
 #ifdef DOC
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFWDIFS* -  DOES THE IMPLICIT CALCULATION FOR SOIL MOISTURE
 
 !     PURPOSE.

--- a/ifs-source/surf/module/srfwexc_mod.F90
+++ b/ifs-source/surf/module/srfwexc_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWEXC_MOD
 CONTAINS
 SUBROUTINE SRFWEXC(KIDIA,KFDIA,KLON,KLEVS,KTILES,&
@@ -22,6 +15,15 @@ USE YOS_THF   , ONLY : RHOH2O
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_VEG   , ONLY : TVEG
 USE YOS_URB   , ONLY : TURB
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 
 !**** *SRFWEXC* -  COMPUTES THE FLUXES BETWEEN THE SOIL LAYERS AND
 !                  THE RIGHT-HAND SIDE OF THE SOIL WATER EQUATIONS.

--- a/ifs-source/surf/module/srfwexc_vg_mod.F90
+++ b/ifs-source/surf/module/srfwexc_vg_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWEXC_VG_MOD
 CONTAINS
 SUBROUTINE SRFWEXC_VG(KIDIA,KFDIA,KLON,KLEVS,KTILES,&
@@ -22,6 +15,15 @@ USE YOS_THF   , ONLY : RHOH2O
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_VEG   , ONLY : TVEG
 USE YOS_URB   , ONLY : TURB
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 
 !**** *SRFWEXC_VG* -  COMPUTES THE FLUXES BETWEEN THE SOIL LAYERS AND
 !                  THE RIGHT-HAND SIDE OF THE SOIL WATER EQUATIONS.

--- a/ifs-source/surf/module/srfwinc_mod.F90
+++ b/ifs-source/surf/module/srfwinc_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWINC_MOD
 CONTAINS
 SUBROUTINE SRFWINC(KIDIA,KFDIA,KLEVS,&
@@ -16,6 +9,14 @@ USE PARKIND1  , ONLY : JPIM, JPRB
 USE YOMHOOK   , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_THF   , ONLY : RHOH2O
 USE YOS_SOIL  , ONLY : TSOIL
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFWINC* -  COMPUTES THE T+1 VALUES OF SOIL MOISTURE
 

--- a/ifs-source/surf/module/srfwl_mod.F90
+++ b/ifs-source/surf/module/srfwl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWL_MOD
 CONTAINS
 SUBROUTINE SRFWL(KIDIA,KFDIA,KTILES,&
@@ -21,6 +14,14 @@ USE YOS_THF   , ONLY : RHOH2O
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_VEG   , ONLY : TVEG
      
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFWL* - COMPUTES CHANGES IN THE SKIN RESERVOIR.
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfwls_mod.F90
+++ b/ifs-source/surf/module/srfwls_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWLS_MOD
 CONTAINS
 SUBROUTINE SRFWLS(KIDIA,KFDIA,KLON,&
@@ -21,6 +14,15 @@ USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_VEG   , ONLY : TVEG
 
 #ifdef DOC
+
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SRFWLS* - COMPUTES CHANGES IN THE SKIN RESERVOIR.
 !     PURPOSE.
 !     --------

--- a/ifs-source/surf/module/srfwng_mod.F90
+++ b/ifs-source/surf/module/srfwng_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SRFWNG_MOD
 CONTAINS
 SUBROUTINE SRFWNG(KIDIA,KFDIA,KLEVS,PTMST,KSOTY,&
@@ -17,6 +10,14 @@ USE PARKIND1  , ONLY : JPIM, JPRB
 USE YOMHOOK   , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_THF   , ONLY : RHOH2O
 USE YOS_SOIL  , ONLY : TSOIL
+
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SRFWNG* -  COMPUTES CORRECTIONS TO AVOID NEGATIVE SOIL MOISTURE.
 

--- a/ifs-source/surf/module/sucotwo_mod.F90
+++ b/ifs-source/surf/module/sucotwo_mod.F90
@@ -1,14 +1,15 @@
-! (C) Copyright 1997- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE  SUCOTWO_MOD
 CONTAINS
 SUBROUTINE SUCOTWO(PRVR0VT,YDVEG,YDCST,YDAGS)
 !***
+! (C) Copyright 1997- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 
 !**   *SUCOTWO* - DOES THE INITIALISATION OF AGS PARAMETERS
 

--- a/ifs-source/surf/module/sufarquhar_mod.F90
+++ b/ifs-source/surf/module/sufarquhar_mod.F90
@@ -1,14 +1,14 @@
-! (C) Copyright 2021- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUFARQUHAR_MOD
 CONTAINS
 SUBROUTINE SUFARQUHAR(PRVCMAX25,PRHUMREL,PRA1,PRB1,PRG0,PRGM25,PRE_VCMAX,PRE_JMAX,YDVEG,YDAGS,YDAGF)
 !***
+! (C) Copyright 2021- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUFARQUHAR* - DOES THE INITIALISATION OF AGS PARAMETERS
  

--- a/ifs-source/surf/module/sugridmlm_mod.F90
+++ b/ifs-source/surf/module/sugridmlm_mod.F90
@@ -1,16 +1,16 @@
-! (C) Copyright 2010- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUGRIDMLM_MOD
 
 CONTAINS
 SUBROUTINE SUGRIDMLM(LD_LOCMLTKE,KCOM,YDMLM)
 !
+! (C) Copyright 2010- ECMWF.
 !
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !***  DETERMINES CONSTANTS AND CONSTANT ARRAYS OF MIXED LAYER MODEL
 !
 !

--- a/ifs-source/surf/module/surfbc_ctl_mod.F90
+++ b/ifs-source/surf/module/surfbc_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1999- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFBC_CTL_MOD
 CONTAINS
 SUBROUTINE SURFBC_CTL(KIDIA, KFDIA, KLON, KTILES,KLEVSN, &
@@ -22,6 +15,14 @@ USE YOS_VEG,      ONLY : TVEG
 USE YOS_FLAKE,    ONLY : TFLAKE
 USE YOS_OCEAN_ML, ONLY : TOCEAN_ML
 USE ABORT_SURF_MOD  
+
+! (C) Copyright 1999- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 !**   *SURFBC* - CREATES BOUNDARY CONDITIONS CHARACTERIZING THE SURFACE

--- a/ifs-source/surf/module/surfexcdriver_ctl_mod.F90
+++ b/ifs-source/surf/module/surfexcdriver_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFEXCDRIVER_CTL_MOD
 CONTAINS
 SUBROUTINE SURFEXCDRIVER_CTL(CDCONF &
@@ -69,6 +62,14 @@ USE SURFSEB_CTL_MOD
 USE SRFCOTWO_MOD
 USE VSFLX_MOD
 USE VLAMSK_MOD 
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/module/surfexcdrivers_ctl_mod.F90
+++ b/ifs-source/surf/module/surfexcdrivers_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFEXCDRIVERS_CTL_MOD
 CONTAINS
 SUBROUTINE SURFEXCDRIVERS_CTL( &
@@ -46,6 +39,14 @@ USE VUPDZ0S_MOD
 USE VSURFS_MOD
 USE VEXCSS_MOD
 USE VEVAPS_MOD
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/module/surfpp_ctl_mod.F90
+++ b/ifs-source/surf/module/surfpp_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFPP_CTL_MOD
 CONTAINS
 SUBROUTINE SURFPP_CTL( KIDIA,KFDIA,KLON,KTILES, KDHVTLS, KDHFTLS &
@@ -35,6 +28,14 @@ USE YOS_FLAKE, ONLY : TFLAKE
 USE SPPCFL_MOD
 USE SPPGUST_MOD
 USE VOSKIN_MOD
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/module/surfpps_ctl_mod.F90
+++ b/ifs-source/surf/module/surfpps_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFPPS_CTL_MOD
 CONTAINS
 SUBROUTINE SURFPPS_CTL( KIDIA,KFDIA,KLON,KTILES,LDPPCFLS &
@@ -27,6 +20,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_EXC  , ONLY : TEXC
 
 USE SPPCFLS_MOD
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------
 

--- a/ifs-source/surf/module/surfrad_ctl_mod.F90
+++ b/ifs-source/surf/module/surfrad_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1991- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFRAD_CTL_MOD
 CONTAINS
 SUBROUTINE SURFRAD_CTL(KDDN,KMMN,KMON,KSECO,&
@@ -32,6 +25,14 @@ USE YOS_FLAKE, ONLY : TFLAKE
 USE YOS_URB  , ONLY : TURB
 USE CANALB_MOD
 USE ABORT_SURF_MOD
+
+! (C) Copyright 1991- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFRAD  - COMPUTES RADIATIVE PROPERTIES OF SURFACE
 

--- a/ifs-source/surf/module/surfseb_ctl_mod.F90
+++ b/ifs-source/surf/module/surfseb_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFSEB_CTL_MOD
 CONTAINS
 SUBROUTINE SURFSEB_CTL(KIDIA,KFDIA,KLON,KTILES,KTVL,KTVH,&
@@ -28,6 +21,14 @@ USE YOS_VEG   , ONLY : TVEG
 USE YOS_FLAKE , ONLY : TFLAKE
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_URB   , ONLY : TURB
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !------------------------------------------------------------------------
 
 !  PURPOSE:

--- a/ifs-source/surf/module/surfsebs_ctl_mod.F90
+++ b/ifs-source/surf/module/surfsebs_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2003- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFSEBS_CTL_MOD
 CONTAINS
 SUBROUTINE SURFSEBS_CTL(KIDIA,KFDIA,KLON,KTILES,KTVL,KTVH,&
@@ -27,6 +20,14 @@ USE YOS_EXC   , ONLY : TEXC
 USE YOS_VEG   , ONLY : TVEG
 USE YOS_FLAKE , ONLY : TFLAKE
 USE YOS_SOIL  , ONLY : TSOIL
+! (C) Copyright 2003- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !------------------------------------------------------------------------
 
 !  PURPOSE:

--- a/ifs-source/surf/module/surftstp_ctl_mod.F90
+++ b/ifs-source/surf/module/surftstp_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1993- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFTSTP_CTL_MOD
 CONTAINS
 SUBROUTINE SURFTSTP_CTL(KIDIA , KFDIA , KLON  , KLEVS , KTILES,&
@@ -101,6 +94,15 @@ USE FLAKE_DRIVER_MOD
 USE OCEAN_ML_DRIVER_V2_MOD   !MIXED_LAYER_PJ
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 1993- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 
 !**** *SURFTSTP* - UPDATES LAND VALUES OF TEMPERATURE, MOISTURE AND SNOW.
 

--- a/ifs-source/surf/module/surftstps_ctl_mod.F90
+++ b/ifs-source/surf/module/surftstps_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFTSTPS_CTL_MOD
 CONTAINS
 SUBROUTINE SURFTSTPS_CTL(KIDIA , KFDIA , KLON  , KLEVS , KLEVSN, &
@@ -44,6 +37,15 @@ USE SRFWLS_MOD
 USE SRFRCGS_MOD
 
 #ifdef DOC
+
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SURFTSTPS* - UPDATES LAND VALUES OF TEMPERATURE AND SNOW.
 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_ctl_mod.F90
+++ b/ifs-source/surf/module/surfws_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_CTL_MOD
 CONTAINS
 SUBROUTINE SURFWS_CTL( KIDIA, KFDIA, KLON, KLEVSN,  &
@@ -31,6 +24,13 @@ USE SURFWS_TSNADJ_MOD
 
 USE ABORT_SURF_MOD
 
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
                    !**** *SURFWS_CTL* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_fgprof.F90
+++ b/ifs-source/surf/module/surfws_fgprof.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_FGPROF_MOD
 CONTAINS
 
@@ -25,6 +18,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFWS_FGPROF* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_init_ml_mod.F90
+++ b/ifs-source/surf/module/surfws_init_ml_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_INIT_ML_MOD
 CONTAINS
 
@@ -27,6 +20,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFWS_INIT_ML* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_init_mloff_mod.F90
+++ b/ifs-source/surf/module/surfws_init_mloff_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_INIT_MLOFF_MOD
 CONTAINS
 
@@ -27,6 +20,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFWS_INIT* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_init_sl_mod.F90
+++ b/ifs-source/surf/module/surfws_init_sl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_INIT_SL_MOD
 CONTAINS
 
@@ -27,6 +20,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFWS_INIT_SL* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_massadj_mod.F90
+++ b/ifs-source/surf/module/surfws_massadj_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_MASSADJ_MOD
 CONTAINS
 
@@ -24,6 +17,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFWS_MASSADJ* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surfws_tsnadj_mod.F90
+++ b/ifs-source/surf/module/surfws_tsnadj_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2017- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURFWS_TSNADJ_MOD
 CONTAINS
 
@@ -25,6 +18,14 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_SOIL , ONLY : TSOIL
 
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2017- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURFWS_TSNADJ* - Snow warm start multi-layer 
 !     PURPOSE.

--- a/ifs-source/surf/module/surwn_mod.F90
+++ b/ifs-source/surf/module/surwn_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1988- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SURWN_MOD
 CONTAINS
 SUBROUTINE SURWN (KSIL,PTSTAND,PXP,PRSUN,YDDIM,YDRAD,YDLW,YDSW)
@@ -16,6 +9,14 @@ USE YOS_RAD   , ONLY : TRAD
 USE YOS_LW    , ONLY : TLW
 USE YOS_SW    , ONLY : TSW
 USE ABORT_SURF_MOD
+! (C) Copyright 1988- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *SURWN*   - INITIALIZE COMMON YOESW
 
 !     PURPOSE.

--- a/ifs-source/surf/module/suscst_mod.F90
+++ b/ifs-source/surf/module/suscst_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSCST_MOD
 CONTAINS
 SUBROUTINE SUSCST(PRCORIOI,PRPLRG,YDCST)
@@ -12,6 +5,14 @@ SUBROUTINE SUSCST(PRCORIOI,PRPLRG,YDCST)
 USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_CST  , ONLY : TCST
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSCST* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOS_CST*
 !              This contains the fundamental model constants

--- a/ifs-source/surf/module/susflake_mod.F90
+++ b/ifs-source/surf/module/susflake_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 ! File %M% from Library %Q%
 ! Version %I% from %G% extracted: %H%
 !------------------------------------------------------------------------------
@@ -13,6 +6,14 @@ MODULE SUSFLAKE_MOD
 
 CONTAINS
 SUBROUTINE SUSFLAKE(LD_LEFLAKE,YDFLAKE)
+
+    ! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------------
 !

--- a/ifs-source/surf/module/susocean_ml_mod.F90
+++ b/ifs-source/surf/module/susocean_ml_mod.F90
@@ -1,14 +1,15 @@
-! (C) Copyright 2008- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSOCEAN_ML_MOD
 
 CONTAINS
 SUBROUTINE SUSOCEAN_ML(LD_LEOCML,YDOCEAN_ML)
+
+! (C) Copyright 2008- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 ! Purpose :
 ! -------

--- a/ifs-source/surf/module/susrad_mod.F90
+++ b/ifs-source/surf/module/susrad_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSRAD_MOD
 CONTAINS
 SUBROUTINE SUSRAD(KSW,KSIL,KTSW,KLWEMISS,&
@@ -20,6 +13,14 @@ USE YOS_RDI   , ONLY : TRDI
 USE YOS_LW    , ONLY : TLW
 USE YOS_SW    , ONLY : TSW
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSRAD* IS THE DRIVER TO ROUTINES SETTING-UP RADIATION CONSTANTS
 !              This contains the fundamental model constants

--- a/ifs-source/surf/module/sussoil_mod.F90
+++ b/ifs-source/surf/module/sussoil_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSSOIL_MOD
 CONTAINS
 SUBROUTINE SUSSOIL(PTHRFRTI,LD_LEVGEN,LD_LESSRO,LD_LESN09,LD_LESNML,PNSNMLWS,&
@@ -15,6 +8,14 @@ USE YOS_DIM   , ONLY : TDIM, JPTEXT
 USE YOS_CST   , ONLY : TCST
 USE YOS_SOIL  , ONLY : TSOIL
 USE CPTAVE_MOD
+
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSSOIL* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOESOIL*
 

--- a/ifs-source/surf/module/susthf_mod.F90
+++ b/ifs-source/surf/module/susthf_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSTHF_MOD
 CONTAINS
 SUBROUTINE SUSTHF(YDCST)
@@ -13,6 +6,14 @@ USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_CST  , ONLY : TCST
 USE YOS_THF  , ONLY : R4LES, R5LES, RHOH2O, R2ES, R4IES, R3LES, R3IES, R5IES, RVTMP2
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSTHF* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOS_CST*
 !              This contains the fundamental model constants

--- a/ifs-source/surf/module/susurb_mod.F90
+++ b/ifs-source/surf/module/susurb_mod.F90
@@ -1,14 +1,15 @@
-! (C) Copyright 2021- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSURB_MOD
 CONTAINS
 !SUBROUTINE SUSURB(LD_LURBAN,LD_LURBUI,YDURB)
 SUBROUTINE SUSURB(YDURB)
+    ! (C) Copyright 2021- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**   *SUSURB* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOS_URB*
 
 !     PURPOSE

--- a/ifs-source/surf/module/susurf_ctl_mod.F90
+++ b/ifs-source/surf/module/susurf_ctl_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSURF_CTL_MOD
 CONTAINS
 SUBROUTINE SUSURF_CTL(KSW,KCSS,KCSNEC,KSIL,KCOM,KTILES,KTSW,KLWEMISS,&
@@ -58,6 +51,14 @@ USE SUSFLAKE_MOD
 
 USE SUGRIDMLM_MOD
 USE SUSURB_MOD
+
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSURF* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOESOIL*
 

--- a/ifs-source/surf/module/susveg_mod.F90
+++ b/ifs-source/surf/module/susveg_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUSVEG_MOD
 CONTAINS
 SUBROUTINE SUSVEG(LD_LELAIV,LD_LECTESSEL,LD_LEAGS,LD_LEFARQUHAR,&
@@ -19,6 +12,14 @@ USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_VEG   , ONLY : TVEG
 
 USE SRFROOTFR_MOD
+
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUSVEG* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOS_VEG*
 

--- a/ifs-source/surf/module/suvexc_mod.F90
+++ b/ifs-source/surf/module/suvexc_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUVEXC_MOD
 CONTAINS
 SUBROUTINE SUVEXC(LD_LEOCWA,LD_LEOCCO,LD_LEOCSA,LD_LEOCLA,&
@@ -15,6 +8,14 @@ SUBROUTINE SUVEXC(LD_LEOCWA,LD_LEOCCO,LD_LEOCSA,LD_LEOCLA,&
 USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_EXC  , ONLY : TEXC
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**   *SUVEXC* IS THE SET-UP ROUTINE FOR COMMON BLOCK *YOS_EXC*

--- a/ifs-source/surf/module/suvexcs_mod.F90
+++ b/ifs-source/surf/module/suvexcs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE SUVEXCS_MOD
 CONTAINS
 
@@ -17,6 +10,14 @@ USE YOS_EXCS  , ONLY : JPRITBL  ,RITBL    ,RIMAX    ,RCHBA    ,&
  & RCHBCD   ,RCHETA   ,RCHETB   ,RCHBHDL  ,&
  & RCDHALF  ,RCHBHDL  ,RCDHPI2  ,DRITBL   ,&
  & RLPBB    ,RLPCC    ,RLPDD
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**   *SUBROUTINE* *SUVEXCS* INITIALIZES COMMON BLOCK *YOEVDFS*
 

--- a/ifs-source/surf/module/tridag_mod.F90
+++ b/ifs-source/surf/module/tridag_mod.F90
@@ -1,16 +1,18 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE TRIDAG_MOD
 
 CONTAINS
 SUBROUTINE TRIDAG(A,B,C,R,U,N,KIDIA,KFDIA,KLON,LLINCR)
 
 USE PARKIND1 ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/vevap_mod.F90
+++ b/ifs-source/surf/module/vevap_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VEVAP_MOD
 CONTAINS
 SUBROUTINE VEVAP(KIDIA,KFDIA,KLON,PTMST,KTILE,&
@@ -19,6 +12,14 @@ USE YOS_THF  , ONLY : RVTMP2
 USE YOS_CST  , ONLY : TCST
 USE YOS_VEG  , ONLY : TVEG
 USE YOS_URB  , ONLY : TURB
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vevaps_mod.F90
+++ b/ifs-source/surf/module/vevaps_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VEVAPS_MOD
 CONTAINS
 SUBROUTINE VEVAPS(KIDIA,KFDIA,KLON,PTMST,PRVDIFTS,KTILE,&
@@ -18,6 +11,14 @@ USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_THF  , ONLY : RVTMP2
 USE YOS_CST  , ONLY : TCST
 USE YOS_VEG  , ONLY : TVEG
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vexcs_mod.F90
+++ b/ifs-source/surf/module/vexcs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VEXCS_MOD
 CONTAINS
 
@@ -22,6 +15,13 @@ USE YOS_EXCS  , ONLY : RCHBCD, DRITBL, RCHBBCD, RCHBB, RCHB23A, RITBL, &
 USE YOS_CST   , ONLY : TCST
 USE YOS_EXC   , ONLY : TEXC
 
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vexcss_mod.F90
+++ b/ifs-source/surf/module/vexcss_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VEXCSS_MOD
 CONTAINS
 SUBROUTINE VEXCSS(KIDIA,KFDIA,KLON,PTMST,PRVDIFTS,&
@@ -20,6 +13,14 @@ USE YOS_THF   , ONLY : RVTMP2
 USE YOS_EXCS  , ONLY : RLPDD, RLPCC, RLPBB
 USE YOS_CST   , ONLY : TCST
 USE YOS_EXC   , ONLY : TEXC
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vlamsk_mod.F90
+++ b/ifs-source/surf/module/vlamsk_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2016- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VLAMSK_MOD
 CONTAINS
 SUBROUTINE VLAMSK(KIDIA,KFDIA,KLON,KTILES,KTVL,KTVH,&
@@ -20,6 +13,14 @@ USE YOS_CST   , ONLY : TCST
 USE YOS_VEG   , ONLY : TVEG
 USE YOS_SOIL  , ONLY : TSOIL
 USE YOS_URB   , ONLY : TURB
+! (C) Copyright 2016- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**   *VLAMSK* - COMPUTE Skin layer conductivity 

--- a/ifs-source/surf/module/voskin_mod.F90
+++ b/ifs-source/surf/module/voskin_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2001- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VOSKIN_MOD
 CONTAINS
 SUBROUTINE VOSKIN(KIDIA,KFDIA,KLON, &
@@ -13,6 +6,14 @@ SUBROUTINE VOSKIN(KIDIA,KFDIA,KLON, &
  & PUMLEV, PVMLEV, PTSKM1M, PSST, PUSTOKES, PVSTOKES,  &
  & YDCST, YDEXC, & 
  & PTSK, PRPLRG)  
+! (C) Copyright 2001- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**   *VOSKIN* - COMPUTES WARM AND COLD SKIN EFFECTS OVER THE OCEAN

--- a/ifs-source/surf/module/vsflx_mod.F90
+++ b/ifs-source/surf/module/vsflx_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1991- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VSFLX_MOD
 CONTAINS
 SUBROUTINE VSFLX(KIDIA,KFDIA,KLON,PTMST,PRVDIFTS,&
@@ -18,6 +11,14 @@ USE PARKIND1 , ONLY : JPIM, JPRB
 USE YOMHOOK  , ONLY : LHOOK, DR_HOOK, JPHOOK
 USE YOS_THF  , ONLY : RVTMP2
 USE YOS_CST  , ONLY : TCST
+
+! (C) Copyright 1991- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vsurf_mod.F90
+++ b/ifs-source/surf/module/vsurf_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VSURF_MOD
 CONTAINS
 SUBROUTINE VSURF(KIDIA,KFDIA,KLON,KTILES,KLEVS,KTILE,&
@@ -35,6 +28,14 @@ USE YOS_SOIL , ONLY : TSOIL
 USE YOS_FLAKE, ONLY : TFLAKE
 USE YOS_URB  , ONLY : TURB
 USE COTWORESTRESS_MOD
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vsurfs_mod.F90
+++ b/ifs-source/surf/module/vsurfs_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VSURFS_MOD
 CONTAINS
 SUBROUTINE VSURFS(KIDIA,KFDIA,KLON,KLEVS,KTILE,&
@@ -24,6 +17,13 @@ USE YOS_CST  , ONLY : TCST
 USE YOS_VEG  , ONLY : TVEG
 USE YOS_SOIL , ONLY : TSOIL
 
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vupdz0_mod.F90
+++ b/ifs-source/surf/module/vupdz0_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VUPDZ0_MOD
 
 USE PARKIND1  , ONLY : JPIM, JPRB, JPRD
@@ -32,6 +25,14 @@ USE YOS_CST   , ONLY : TCST
 USE YOS_VEG   , ONLY : TVEG
 USE YOS_FLAKE , ONLY : TFLAKE
 USE YOS_URB   , ONLY : TURB
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/vupdz0s_mod.F90
+++ b/ifs-source/surf/module/vupdz0s_mod.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE VUPDZ0S_MOD
 USE PARKIND1  , ONLY : JPIM, JPRB
 
@@ -30,6 +23,14 @@ USE YOS_CST   , ONLY : TCST
 USE YOS_EXC   , ONLY : TEXC
 USE YOS_VEG   , ONLY : TVEG
 USE YOS_FLAKE , ONLY : TFLAKE
+
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/module/yos_agf.F90
+++ b/ifs-source/surf/module/yos_agf.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_AGF
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE
 SAVE
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     -----------------------------------------------------------------
 !*    ** *AGF* - 

--- a/ifs-source/surf/module/yos_ags.F90
+++ b/ifs-source/surf/module/yos_ags.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_AGS
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE
 SAVE
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !     -----------------------------------------------------------------
 !*    ** *AGS* - 

--- a/ifs-source/surf/module/yos_cst.F90
+++ b/ifs-source/surf/module/yos_cst.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_CST
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
   
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_dim.F90
+++ b/ifs-source/surf/module/yos_dim.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_DIM
  
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_exc.F90
+++ b/ifs-source/surf/module/yos_exc.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_EXC
  
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_excs.F90
+++ b/ifs-source/surf/module/yos_excs.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_EXCS
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_flake.F90
+++ b/ifs-source/surf/module/yos_flake.F90
@@ -1,15 +1,16 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 ! File %M% from Library %Q%
 ! Version %I% from %G% extracted: %H%
 !------------------------------------------------------------------------------
 
 MODULE YOS_FLAKE
+
+    ! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------------
 !

--- a/ifs-source/surf/module/yos_lw.F90
+++ b/ifs-source/surf/module/yos_lw.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_LW
  
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_mlm.F90
+++ b/ifs-source/surf/module/yos_mlm.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2011- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_MLM
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2011- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_ocean_ml.F90
+++ b/ifs-source/surf/module/yos_ocean_ml.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_OCEAN_ML
 
 ! YOS_OCEAN_ML : Data Module for the Ocean Mixed Layer Model.
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !---------------------------------------------------------------------
 

--- a/ifs-source/surf/module/yos_rad.F90
+++ b/ifs-source/surf/module/yos_rad.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_RAD
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_rdi.F90
+++ b/ifs-source/surf/module/yos_rdi.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_RDI
   
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_soil.F90
+++ b/ifs-source/surf/module/yos_soil.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_SOIL
 
 USE PARKIND1,ONLY : JPIM, JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_surf.F90
+++ b/ifs-source/surf/module/yos_surf.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_SURF
  
 USE YOS_AGS     , ONLY : TAGS
@@ -25,6 +18,14 @@ USE YOS_URB     , ONLY : TURB
 
 USE ISO_C_BINDING
 USE ABORT_SURF_MOD
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_sw.F90
+++ b/ifs-source/surf/module/yos_sw.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_SW
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_thf.F90
+++ b/ifs-source/surf/module/yos_thf.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_THF
  
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/module/yos_urb.F90
+++ b/ifs-source/surf/module/yos_urb.F90
@@ -1,11 +1,12 @@
+MODULE YOS_URB
+
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOS_URB
+! nor does it submit to any jurisdiction.
 
 !------------------------------------------------------------------------------
 

--- a/ifs-source/surf/module/yos_veg.F90
+++ b/ifs-source/surf/module/yos_veg.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOS_VEG
  
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 !prepifs tp

--- a/ifs-source/surf/offline/driver/callpar1s.F90
+++ b/ifs-source/surf/offline/driver/callpar1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE CALLPAR1S (CDCONF &
      & , KIDIA,KFDIA,KLON,KLEVS,KTILES,KVTYPES &
      & , KLEV   ,KSTART ,KSTEP  ,KTRAC   &
@@ -73,6 +66,14 @@ SUBROUTINE CALLPAR1S (CDCONF &
      & , PUOE1   ,PVOE1    ,PTOE1    ,PSOE1 &             !KPP
      & , PLAIE1, PBSTRE1, PBSTR2E1 &
      & , PDHTLS,PDHTSS,PDHTTS,PDHTIS,PDHIIS,PDHSSS,PDHWLS,PDHRESS,PDHCO2S,PDHBIOS,PDHVEGS)
+
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *CALLPAR1S * - CALL PHYSICS
 

--- a/ifs-source/surf/offline/driver/cnt01s.F90
+++ b/ifs-source/surf/offline/driver/cnt01s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE CNT01S
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD
 USE YOMHOOK   ,ONLY : LHOOK   , DR_HOOK, JPHOOK
@@ -14,6 +7,14 @@ USE MPL_MODULE
 USE CMF_DRV_CONTROL_MOD,  ONLY: CMF_DRV_INIT, CMF_DRV_INPUT
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 
 !**** *CNT01S*  - Routine which controls the job at level 0.
 

--- a/ifs-source/surf/offline/driver/cnt21s.F90
+++ b/ifs-source/surf/offline/driver/cnt21s.F90
@@ -1,11 +1,11 @@
+SUBROUTINE CNT21S
 ! (C) Copyright 1995- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE CNT21S
+! nor does it submit to any jurisdiction.
 
 !**** *CNT21S*  -  Controls integration job at level 2.
 

--- a/ifs-source/surf/offline/driver/cnt31s.F90
+++ b/ifs-source/surf/offline/driver/cnt31s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE CNT31S
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -13,6 +6,13 @@ USE YOMDPHY  , ONLY : NPDONE
 
 IMPLICIT NONE
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *CNT31S*  - Controls integration job at level 3
 

--- a/ifs-source/surf/offline/driver/cnt41s.F90
+++ b/ifs-source/surf/offline/driver/cnt41s.F90
@@ -1,11 +1,13 @@
+SUBROUTINE CNT41S
 ! (C) Copyright 1995- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE CNT41S
+! nor does it submit to any jurisdiction.
+
+
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 
@@ -28,7 +30,6 @@ USE YOMGPD1S , ONLY: VFPGLOB, VFCLAKE, VFCLAKEF,  VFITM
 USE OMP_LIB
 USE MPL_MODULE
 #ifdef DOC
-
 !**** *CNT41S*  - Controls integration job at level 4
 
 !     Purpose.

--- a/ifs-source/surf/offline/driver/cntend.F90
+++ b/ifs-source/surf/offline/driver/cntend.F90
@@ -1,14 +1,14 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE CNTEND
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *CNTEND*  - Closes netCDF datafiles.
 

--- a/ifs-source/surf/offline/driver/cpg1s.F90
+++ b/ifs-source/surf/offline/driver/cpg1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE CPG1S
 
 USE YOMDPHY  ,  ONLY : NCSS     ,NLEV     ,NGPP     ,NPOI     ,NTILES   ,&
@@ -80,6 +73,14 @@ USE OMP_LIB
 USE MPL_MODULE
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *CPG1S* - Grid point calculations.
 
 !     Purpose.

--- a/ifs-source/surf/offline/driver/dattim.F90
+++ b/ifs-source/surf/offline/driver/dattim.F90
@@ -1,13 +1,13 @@
-! (C) Copyright 1996- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE DATTIM(PJUL,KYMD,KHM)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB , JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
+! (C) Copyright 1996- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *DATTIM*  - Gives time of the model in the format yyyymmdd and hhmm
 

--- a/ifs-source/surf/offline/driver/dtforc.F90
+++ b/ifs-source/surf/offline/driver/dtforc.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE DTFORC
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB , JPRD
@@ -29,6 +22,13 @@ USE YOEPHY   , ONLY : LEAIRCO2COUP
 
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *DTFORC *  - TIME INTERPOLATION OF THE ATMOSPHERIC FORCING DATA
 

--- a/ifs-source/surf/offline/driver/ibm.F90
+++ b/ifs-source/surf/offline/driver/ibm.F90
@@ -1,11 +1,12 @@
+SUBROUTINE VDIV
 ! (C) Copyright 1995- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE VDIV
+! nor does it submit to any jurisdiction.
+
 ! EMULATOR FOR IBM INTRINSIC FUNCTION
 use abort_surf_mod
 call abort_surf('vdiv: should not have been called')

--- a/ifs-source/surf/offline/driver/incdat.F90
+++ b/ifs-source/surf/offline/driver/incdat.F90
@@ -1,11 +1,11 @@
+SUBROUTINE INCDAT(KIN,KD,KOU)
 ! (C) Copyright 1996- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE INCDAT(KIN,KD,KOU)
+! nor does it submit to any jurisdiction.
 
 !**** *INCDAT*  - Increments a date by a positive number of days
 

--- a/ifs-source/surf/offline/driver/minmax.F90
+++ b/ifs-source/surf/offline/driver/minmax.F90
@@ -1,13 +1,13 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE MINMAX ( CNAME, PA, KLON, KLAT, LMASK, KULOUT )
 
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *MINMAX * - SPECIFYING STATISTICS OF ARRAY
 

--- a/ifs-source/surf/offline/driver/netcdf_utils.F90
+++ b/ifs-source/surf/offline/driver/netcdf_utils.F90
@@ -1,11 +1,11 @@
+MODULE NETCDF_UTILS
 ! (C) Copyright 1995- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE NETCDF_UTILS
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM,JPRB 
 USE NETCDF
 USE MPL_MODULE

--- a/ifs-source/surf/offline/driver/parkind1.F90
+++ b/ifs-source/surf/offline/driver/parkind1.F90
@@ -1,12 +1,12 @@
+MODULE PARKIND1
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE PARKIND1
-!
+! nor does it submit to any jurisdiction.
+
 !     *** Define usual kinds for strong typing ***
 !
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/ptrgp1s.F90
+++ b/ifs-source/surf/offline/driver/ptrgp1s.F90
@@ -1,11 +1,12 @@
+MODULE PTRGP1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE PTRGP1S
+! nor does it submit to any jurisdiction.
+
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/ptrgpd1s.F90
+++ b/ifs-source/surf/offline/driver/ptrgpd1s.F90
@@ -1,11 +1,12 @@
+MODULE PTRGPD1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE PTRGPD1S
+! nor does it submit to any jurisdiction.
+
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/rdclim.F90
+++ b/ifs-source/surf/offline/driver/rdclim.F90
@@ -1,14 +1,14 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE RDCLIM(NCID)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *RDCLIM * - Reading netCDF file containing surface climate fields
 

--- a/ifs-source/surf/offline/driver/rdcoor.F90
+++ b/ifs-source/surf/offline/driver/rdcoor.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE RDCOOR(NCID,LOPLEFT)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,    JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 USE MPL_MODULE
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *RDCOOR* - Reading netCDF file containing point coordinates
 

--- a/ifs-source/surf/offline/driver/rdfvar.F90
+++ b/ifs-source/surf/offline/driver/rdfvar.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE RDFVAR(CFILE,CVAR,POUTPUT)
 
 USE YOMFORC1S, ONLY : JPSTPFC  , DTIMFC   ,RTSTFC   ,NSTPFC,DIMFORC
@@ -22,6 +15,13 @@ USE NETCDF_UTILS, ONLY: NCERROR
 USE YOMHOOK  ,ONLY : DR_HOOK, JPHOOK, LHOOK
 USE MPL_MODULE
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *RDFVAR  * - ROUTINE TO READ A SINGLE FIELD FROM A NETCDF FILE
 !

--- a/ifs-source/surf/offline/driver/rdres.F90
+++ b/ifs-source/surf/offline/driver/rdres.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE RDRES(LOPLEFT)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *RDRES*   - Routine to read restart file
 

--- a/ifs-source/surf/offline/driver/rdsupr.F90
+++ b/ifs-source/surf/offline/driver/rdsupr.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE RDSUPR(NCID)
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
@@ -28,6 +21,13 @@ USE NETCDF
 USE NETCDF_UTILS, ONLY: NCERROR
 USE MPL_MODULE
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *RDSUPR * - Reading netCDF file containing surface prognostic fields
 

--- a/ifs-source/surf/offline/driver/stepo1s.F90
+++ b/ifs-source/surf/offline/driver/stepo1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE STEPO1S
 USE PARKIND1  ,ONLY : JPIM     ,JPRB      ,JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -17,6 +10,13 @@ USE YOMGDI1S , ONLY : GDI1S    ,N2DDI    ,GDIAUX1S ,N2DDIAUX ,D1SWAFR
 USE YOMDPHY  , ONLY : NPOI     ,NGPP     ,NGPA
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *STEPO1S*  - Controls integration job at lowest level
 

--- a/ifs-source/surf/offline/driver/su0phy1s.F90
+++ b/ifs-source/surf/offline/driver/su0phy1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1991- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SU0PHY1S(KULOUT)
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD
@@ -20,6 +13,13 @@ USE YOEPHY   , ONLY : LERADS   ,LESICE   ,LESURF   ,LEVDIF ,RTHRFRTI,&
 USE YOMLOG1S , ONLY : LWRLKE
 
 #ifdef DOC
+! (C) Copyright 1991- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SU0PHY*   - Initialize common YOxPHY controlling physics
 

--- a/ifs-source/surf/offline/driver/su0yom1s.F90
+++ b/ifs-source/surf/offline/driver/su0yom1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SU0YOM1S
 USE PARKIND1    ,ONLY : JPIM     ,JPRB,    JPRD
 USE YOMLUN1S    ,ONLY : NULOUT   ,NULNAM
@@ -12,6 +5,13 @@ USE YOMRIP      ,ONLY : NINDAT   ,NSSSSS
 USE MPL_MODULE
 USE YOMHOOK     ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SU0YOM1S*  - INITIALIZE LEVEL 0 COMMONS
 

--- a/ifs-source/surf/offline/driver/su1s.F90
+++ b/ifs-source/surf/offline/driver/su1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SU1S
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK, ONLY   : LHOOK    ,DR_HOOK, JPHOOK
@@ -21,6 +14,13 @@ USE YOMLOG1S , ONLY : LDBGS1   ,LACCUMW , LSEMISS , CFFORC &
 USE YOMLUN1S , ONLY : NULNAM   ,NULOUT
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SU1s* - Initialize common YOMLOG1S controlling multi-column surface model 
 

--- a/ifs-source/surf/offline/driver/sucdfres.F90
+++ b/ifs-source/surf/offline/driver/sucdfres.F90
@@ -1,13 +1,13 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUCDFRES
 
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUCDFFL * - Routine to initialize NetCDF output
 

--- a/ifs-source/surf/offline/driver/sucdh1s.F90
+++ b/ifs-source/surf/offline/driver/sucdh1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUCDH1S
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD
@@ -18,6 +11,13 @@ USE YOMCDH1S   ,ONLY : NLEVI   , &
      &  NDHVCO2S,NDHFCO2S, &
      &  NDHVBIOS,NDHFBIOS,NDHVVEGS,NDHFVEGS
 
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/offline/driver/sucst.F90
+++ b/ifs-source/surf/offline/driver/sucst.F90
@@ -1,11 +1,11 @@
+SUBROUTINE SUCST(KULOUT,KDAT,KSSS,KPRINTLEV)
 ! (C) Copyright 1987- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SUCST(KULOUT,KDAT,KSSS,KPRINTLEV)
+! nor does it submit to any jurisdiction.
 
 !**** *SUCST * - Routine to initialize the constants of the model.
 

--- a/ifs-source/surf/offline/driver/suct01s.F90
+++ b/ifs-source/surf/offline/driver/suct01s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUCT01S(KULOUT)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -16,6 +9,13 @@ USE YOMCT01S , ONLY : JPNPST   ,NPOSTS   ,NHISTS   ,&
 
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUCT01S*   - Routine to initialize level 0 control common
 

--- a/ifs-source/surf/offline/driver/sudcdf.F90
+++ b/ifs-source/surf/offline/driver/sudcdf.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUDCDF
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUDCDF * - Routine to initialize NetCDF output
 

--- a/ifs-source/surf/offline/driver/sudim1s.F90
+++ b/ifs-source/surf/offline/driver/sudim1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUDIM1S
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,    JPRD
@@ -23,6 +16,13 @@ USE YOMFORC1S, ONLY : JPSTPFC
 USE YOEPHY   , ONLY : LEOCML   ,LEFLAKE  ,LEURBAN, LECTESSEL, LECLIM10D
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUDIM1S * - Setting up of the dimensions of the surface
 !                  multi-column model

--- a/ifs-source/surf/offline/driver/sudyn1s.F90
+++ b/ifs-source/surf/offline/driver/sudyn1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUDYN1S(KULOUT)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB          ,JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -13,6 +6,13 @@ USE YOMLUN1S , ONLY : NULNAM
 USE YOMRIP   , ONLY : RTIMTR   ,RTIMST
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUDYN1S*   - Initialize constants and control for temporal evolution
 !                   of the one-column surface model

--- a/ifs-source/surf/offline/driver/sufcdf.F90
+++ b/ifs-source/surf/offline/driver/sufcdf.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUFCDF
 
 USE YOMFORC1S, ONLY : JPSTPFC  ,UFI      ,VFI      ,TFI      ,&
@@ -32,6 +25,13 @@ USE YOMHOOK   ,ONLY : DR_HOOK, JPHOOK, LHOOK
 USE MPL_MODULE
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUFCDF  * - ROUTINE TO SETUP THE ATMOSPHERIC FORCING DATA
 !                  FROM NETCDF INPUT

--- a/ifs-source/surf/offline/driver/sugc1s.F90
+++ b/ifs-source/surf/offline/driver/sugc1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUGC1S(NCID,LOPLEFT)
 USE PARKIND1  ,ONLY : JPIM ,JPRB, JPRD
 USE YOMHOOK   ,ONLY : LHOOK     ,DR_HOOK, JPHOOK
@@ -33,6 +26,13 @@ USE NETCDF_UTILS, ONLY : NCERROR
 USE MPL_MODULE
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUGC1S*  - Routine to initialize geometry parameters
 

--- a/ifs-source/surf/offline/driver/sugdi1s.F90
+++ b/ifs-source/surf/offline/driver/sugdi1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1997- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUGDI1S
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -81,6 +74,13 @@ USE YOMGDI1S , ONLY : GDI1S    ,GDIAUX1S ,&
             &D1STISKC,D1STISKC2,D1SPSURF,D1SPSURF2
 
 #ifdef DOC
+! (C) Copyright 1997- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUDIM1S * - Allocates space for the diagnostics
 !                  in the surface one-column model

--- a/ifs-source/surf/offline/driver/sugp1s.F90
+++ b/ifs-source/surf/offline/driver/sugp1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUGP1S(NCID)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -48,6 +41,13 @@ USE YOMDPHY  , ONLY : NCSS     ,NGPP     ,NPOI ,NGPA ,NVHILO,&
 
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUGP1S*   - Routine to initialize prognostic variables
 

--- a/ifs-source/surf/offline/driver/sugpd1s.F90
+++ b/ifs-source/surf/offline/driver/sugpd1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUGPD1S(NCID)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -65,6 +58,13 @@ USE YOMDPHY  , ONLY : NVSF    ,NVPD     ,NGCC     ,NPOI     ,&
 USE YOEPHY   , ONLY : LEOCML, LECLIM10D
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUGPD1S*   - Routine to initialize soil and vegetation properties
 

--- a/ifs-source/surf/offline/driver/suinif1s.F90
+++ b/ifs-source/surf/offline/driver/suinif1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUINIF1S(LOPLEFT)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -21,6 +14,14 @@ USE YOMGF1S  , ONLY : UNLEV0   ,VNLEV0   ,TNLEV0   ,QNLEV0   ,CNLEV0 ,&
                       &QNLEV1   ,CNLEV1   ,FSSRD    ,FSTRD    ,FLSRF    ,&
                       &FCRF     ,FLSSF    ,FCSF , PNLP1
 USE MPL_MODULE
+
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUINIF1S*  - Initialize the fields of the one column surface model.
 

--- a/ifs-source/surf/offline/driver/sulun1s.F90
+++ b/ifs-source/surf/offline/driver/sulun1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SULUN1S
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB, JPRD
@@ -27,6 +20,13 @@ USE YOMCST   , ONLY : RDAY
 USE YOMRIP   , ONLY : NINDAT   ,NSSSSS
 USE NETCDF
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SULUN1S * - Routine to initialize the common YOMLUN1S
 

--- a/ifs-source/surf/offline/driver/sulwn.F90
+++ b/ifs-source/surf/offline/driver/sulwn.F90
@@ -1,11 +1,11 @@
+SUBROUTINE SULWN
 ! (C) Copyright 1988- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SULWN
+! nor does it submit to any jurisdiction.
 
 !**** *SULWN*   - INITIALIZE COMMON YOELW
 

--- a/ifs-source/surf/offline/driver/suoptsurf.F90
+++ b/ifs-source/surf/offline/driver/suoptsurf.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2021- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUOPTSURF(KULOUT)
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
@@ -19,6 +12,13 @@ USE YOEOPTSURF   , ONLY : RVR0VT, RVCMAX25,RHUMREL,RA1,RB1,RG0,RGM25,RE_VCMAX,RE
 
 
 #ifdef DOC
+! (C) Copyright 2021- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUOPTSURF*   - Initialize common YOEOPTSURF optimised parameters in land surface model
 

--- a/ifs-source/surf/offline/driver/supcdf.F90
+++ b/ifs-source/surf/offline/driver/supcdf.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUPCDF
 USE PARKIND1  ,ONLY : JPIM     ,JPRB, JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
 
 #ifdef DOC
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUPCDF * - Routine to initialize prognostic NetCDF output
 

--- a/ifs-source/surf/offline/driver/suphec.F90
+++ b/ifs-source/surf/offline/driver/suphec.F90
@@ -1,12 +1,12 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SUPHEC(KULOUT)
 
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SUPHEC - INITIALISES PHYSICAL CONSTANTS OF UNCERTAIN VALUE.
 !               WITHIN THE E.C.M.W.F. PHYSICS PACKAGE

--- a/ifs-source/surf/offline/driver/surdi.F90
+++ b/ifs-source/surf/offline/driver/surdi.F90
@@ -1,11 +1,11 @@
+SUBROUTINE SURDI
 ! (C) Copyright 1988- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SURDI
+! nor does it submit to any jurisdiction.
 
 !**** *SURDI*   - INITIALIZE COMMON YOERDI CONTROLLING RADINT
 

--- a/ifs-source/surf/offline/driver/surdi1s.F90
+++ b/ifs-source/surf/offline/driver/surdi1s.F90
@@ -1,15 +1,15 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURDI1S
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 USE YOERDI1S , ONLY : REMISS
 
 #ifdef DOC
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURDI1s* - Initialize common YOERDI1S
 !     ------------------------------------------------------------------

--- a/ifs-source/surf/offline/driver/surip.F90
+++ b/ifs-source/surf/offline/driver/surip.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1987- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE SURIP(KULOUT)
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
@@ -16,6 +9,13 @@ USE YOMRIP   , ONLY : NINDAT   ,NSSSSS   ,NSTADD   ,NSTASS   ,&
             &RDTSA2   ,RDTS62   ,RDTS22   ,RTDT
 
 #ifdef DOC
+! (C) Copyright 1987- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *SURIP * - Routine to initialize the common YOMRIP
 

--- a/ifs-source/surf/offline/driver/suswn.F90
+++ b/ifs-source/surf/offline/driver/suswn.F90
@@ -1,11 +1,11 @@
+SUBROUTINE SUSWN (KTSW, KSW)
 ! (C) Copyright 1988- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SUSWN (KTSW, KSW)
+! nor does it submit to any jurisdiction.
 
 !**** *SUSW*   - INITIALIZE COMMON YOESW
 

--- a/ifs-source/surf/offline/driver/suvdf.F90
+++ b/ifs-source/surf/offline/driver/suvdf.F90
@@ -1,11 +1,11 @@
+SUBROUTINE SUVDF
 ! (C) Copyright 1989- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SUVDF
+! nor does it submit to any jurisdiction.
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/offline/driver/suvdfs.F90
+++ b/ifs-source/surf/offline/driver/suvdfs.F90
@@ -1,11 +1,11 @@
+SUBROUTINE SUVDFS
 ! (C) Copyright 1990- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE SUVDFS
+! nor does it submit to any jurisdiction.
 
 !**   *SUBROUTINE* *SUVDFS* INITIALIZES COMMON BLOCK *YOEVDFS*
 

--- a/ifs-source/surf/offline/driver/updcal.F90
+++ b/ifs-source/surf/offline/driver/updcal.F90
@@ -1,11 +1,11 @@
+SUBROUTINE UPDCAL(KD0,KM0,KY0,KINC,KD1,KM1,KY1,KLMO,KULOUT)
 ! (C) Copyright 1991- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE UPDCAL(KD0,KM0,KY0,KINC,KD1,KM1,KY1,KLMO,KULOUT)
+! nor does it submit to any jurisdiction.
 
 !**** *UPDCAL*
 

--- a/ifs-source/surf/offline/driver/upddiag.F90
+++ b/ifs-source/surf/offline/driver/upddiag.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 2010- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE UPDDIAG( &
  & KIDIA,KFDIA,KLON,KLEV,KLEVS,KLEVSN,KTILES,KVTYPES, &
  & KDHVTLS,KDHFTLS,KDHVTSS,KDHFTSS, &
@@ -24,6 +17,13 @@ SUBROUTINE UPDDIAG( &
  & PDHTLS,PDHTSS,PDHTTS,PDHSSS,PDHIIS,PDHWLS,PDHRESS,&
  & PT2M,PD2M,PDHCO2S,PDHBIOS,PDHVEGS)
 
+! (C) Copyright 2010- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !
 !**** UPDDIAG - INTERFACE ROUTINE TO COPY IFS VARIABLES TO
 !		OFFLINE CODE DIAGNOSTICS BUFFERS

--- a/ifs-source/surf/offline/driver/updtim1s.F90
+++ b/ifs-source/surf/offline/driver/updtim1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1995- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE UPDTIM1S(KSTEP,PTDT,PTSTEP)
 
 
@@ -31,6 +24,13 @@ USE YOEPHY, ONLY: LECTESSEL, LECLIM10D
 USE YOMCT01S , ONLY : NSTART
 
 #ifdef DOC
+! (C) Copyright 1995- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *UPDTIM1S* - UPDATE TIME OF THE ONE COLUMN SURFACE MODEL 
 

--- a/ifs-source/surf/offline/driver/vdfdifc.F90
+++ b/ifs-source/surf/offline/driver/vdfdifc.F90
@@ -1,12 +1,13 @@
-! (C) Copyright 2004- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE VDFDIFC(KIDIA,KFDIA,KLON,KLEV,KTOP,KTRAC,&
                  & PTMST,PCM1,PTENC,PAPHM1,PCFH,PCFLX)  
+! (C) Copyright 2004- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**   *VDFDIFC* - Does the implicit computation for diffusion of tracers

--- a/ifs-source/surf/offline/driver/vdfdifh1s.F90
+++ b/ifs-source/surf/offline/driver/vdfdifh1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE VDFDIFH1S(&
  & KIDIA  , KFDIA  , KLON   , KLEV   , KTOP   , KTILES , KTVL   , KTVH , KLEVSN,&
  & PTMST  , PFSH1D , PFLH1D , LDFLUX1D, &
@@ -18,6 +11,13 @@ SUBROUTINE VDFDIFH1S(&
  & PTSNOW , PTICE  , PSST, &
  & PTSKTIP1, PSLGE  , PTE    , PQTE, &
  & PJQ,PSSH,PSLH,PSTR,PG0,PJQU)  
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !     ------------------------------------------------------------------
 
 !**   *VDFDIFH* - DOES THE IMPLICIT CALCULATION FOR DIFFUSION OF S. L.

--- a/ifs-source/surf/offline/driver/vdfdifm1s.F90
+++ b/ifs-source/surf/offline/driver/vdfdifm1s.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 1989- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE VDFDIFM1S(KIDIA,KFDIA,KLON,KLEV,KTOP,&
  & PTMST,PUM1,PVM1,PAPHM1,PCFM,&
  & PVOM,PVOL,PUDIF,PVDIF)  
+! (C) Copyright 1989- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**   *VDFDIFM* - DOES THE IMLPLICIT CALCULATION FOR MOMENTUM DIFFUSION

--- a/ifs-source/surf/offline/driver/vdfincr.F90
+++ b/ifs-source/surf/offline/driver/vdfincr.F90
@@ -1,15 +1,16 @@
-! (C) Copyright 1990- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE VDFINCR(KIDIA  , KFDIA  , KLON   , KLEV   , KTOP   , PTMST  , &
  & PUM1   , PVM1   , PSLGM1 , PTM1   , PQTM1  , PAPHM1 , PGEOM1 , &
  & PCFM   , PUDIF  , PVDIF  , PSLGDIF, PQTDIF , &
  & PVOM   , PVOL   , PSLGE  , PQTE   , PSLGEWODIS, &
  & PVDIS  , PSTRTU , PSTRTV)  
+! (C) Copyright 1990- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 !**   *VDFINCR* - INCREMENTS U,V,T AND Q-TENDENCIES; COMPUTE MULTILEVEL

--- a/ifs-source/surf/offline/driver/vdfmain1s.F90
+++ b/ifs-source/surf/offline/driver/vdfmain1s.F90
@@ -1,10 +1,3 @@
-! (C) Copyright 1982- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 !OPTIONS XOPT(HSFUN)
 SUBROUTINE VDFMAIN1S  ( CDCONF, &
  & KIDIA  , KFDIA  , KLON   , KLEV   , KLEVS  , KSTEP  , KTILES , KVTYPES, KDIAG, &
@@ -39,6 +32,13 @@ SUBROUTINE VDFMAIN1S  ( CDCONF, &
  ! DDH OUTPUTS
  & PDHTLS , PDHTSS , PDHTTS , PDHTIS, PDHCO2S,PDHVEGS )
 
+! (C) Copyright 1982- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 !***
 
 !**   *VDFMAIN1S* - DOES THE VERTICAL EXCHANGE OF U,V,SLG,QT BY TURBULENCE.

--- a/ifs-source/surf/offline/driver/wrtclim.F90
+++ b/ifs-source/surf/offline/driver/wrtclim.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE WRTCLIM
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,  JPRD
 USE YOMHOOK   ,ONLY : DR_HOOK, JPHOOK  ,LHOOK
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *WRTCLIM*  - writes fixed climate fields to NetCDF files
 
 !     Purpose.

--- a/ifs-source/surf/offline/driver/wrtd1s.F90
+++ b/ifs-source/surf/offline/driver/wrtd1s.F90
@@ -1,11 +1,11 @@
+      SUBROUTINE WRTD1S
 ! (C) Copyright 1995- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-      SUBROUTINE WRTD1S
+! nor does it submit to any jurisdiction.
 
 !**** *WRTP1S*  - Writing diagnostic variables of the one-column
 !                 surface model

--- a/ifs-source/surf/offline/driver/wrtd2cdf.F90
+++ b/ifs-source/surf/offline/driver/wrtd2cdf.F90
@@ -1,13 +1,13 @@
-! (C) Copyright 2013- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE WRTD2CDF
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,   JPRD, JPRM
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
+! (C) Copyright 2013- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *WRTDCDF*  - writes diagnostics to NetCDF files, 2 meter diagnostic
 

--- a/ifs-source/surf/offline/driver/wrtdcdf.F90
+++ b/ifs-source/surf/offline/driver/wrtdcdf.F90
@@ -1,13 +1,14 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE WRTDCDF
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,JPRM,JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 !**** *WRTDCDF*  - writes diagnostics to NetCDF files
 
 !     Purpose.

--- a/ifs-source/surf/offline/driver/wrtp1s.F90
+++ b/ifs-source/surf/offline/driver/wrtp1s.F90
@@ -1,11 +1,11 @@
+      SUBROUTINE WRTP1S
 ! (C) Copyright 1995- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-      SUBROUTINE WRTP1S
+! nor does it submit to any jurisdiction.
 
 !**** *WRTP1S*  - Writing prognostic variables of the one-column surface model
 

--- a/ifs-source/surf/offline/driver/wrtpcdf.F90
+++ b/ifs-source/surf/offline/driver/wrtpcdf.F90
@@ -1,11 +1,11 @@
+SUBROUTINE WRTPCDF
 ! (C) Copyright 2000- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-SUBROUTINE WRTPCDF
+! nor does it submit to any jurisdiction.
 
 !**** *WRTPCDF*  - Writing prognostic variables of the one-column surface model
 

--- a/ifs-source/surf/offline/driver/wrtres.F90
+++ b/ifs-source/surf/offline/driver/wrtres.F90
@@ -1,13 +1,13 @@
-! (C) Copyright 2000- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 SUBROUTINE WRTRES
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,JPRM,JPRD
 USE YOMHOOK   ,ONLY : LHOOK    ,DR_HOOK, JPHOOK
+! (C) Copyright 2000- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 !**** *WRTRES*  - writes NetCDF restart file
 

--- a/ifs-source/surf/offline/driver/yoelw.F90
+++ b/ifs-source/surf/offline/driver/yoelw.F90
@@ -1,13 +1,13 @@
-! (C) Copyright 2005- ECMWF.
-! This software is licensed under the terms of the Apache Licence Version 2.0
-! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
-! In applying this licence, ECMWF does not waive the privileges and immunities
-! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
 MODULE YOELW
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
 
 IMPLICIT NONE
 

--- a/ifs-source/surf/offline/driver/yoeoptsurf.F90
+++ b/ifs-source/surf/offline/driver/yoeoptsurf.F90
@@ -1,11 +1,11 @@
+MODULE YOEOPTSURF
 ! (C) Copyright 2021- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOEOPTSURF
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPRB, JPIM
 

--- a/ifs-source/surf/offline/driver/yoephy.F90
+++ b/ifs-source/surf/offline/driver/yoephy.F90
@@ -1,11 +1,11 @@
+MODULE YOEPHY
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOEPHY
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPRB, JPIM
 

--- a/ifs-source/surf/offline/driver/yoerad.F90
+++ b/ifs-source/surf/offline/driver/yoerad.F90
@@ -1,11 +1,11 @@
+MODULE YOERAD
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOERAD
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yoerdi.F90
+++ b/ifs-source/surf/offline/driver/yoerdi.F90
@@ -1,11 +1,11 @@
+MODULE YOERDI
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOERDI
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPRB
 

--- a/ifs-source/surf/offline/driver/yoerdi1s.F90
+++ b/ifs-source/surf/offline/driver/yoerdi1s.F90
@@ -1,11 +1,11 @@
+MODULE YOERDI1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOERDI1S
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yoerip.F90
+++ b/ifs-source/surf/offline/driver/yoerip.F90
@@ -1,11 +1,11 @@
+MODULE YOERIP
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOERIP
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB,JPRD
 

--- a/ifs-source/surf/offline/driver/yoesoil1s.F90
+++ b/ifs-source/surf/offline/driver/yoesoil1s.F90
@@ -1,11 +1,11 @@
+MODULE YOESOIL1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOESOIL1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yoesw.F90
+++ b/ifs-source/surf/offline/driver/yoesw.F90
@@ -1,11 +1,11 @@
+MODULE YOESW
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOESW
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yoethf.F90
+++ b/ifs-source/surf/offline/driver/yoethf.F90
@@ -1,11 +1,11 @@
+MODULE YOETHF
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOETHF
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yoevdf.F90
+++ b/ifs-source/surf/offline/driver/yoevdf.F90
@@ -1,11 +1,11 @@
+MODULE YOEVDF
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOEVDF
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yoevdfs.F90
+++ b/ifs-source/surf/offline/driver/yoevdfs.F90
@@ -1,11 +1,11 @@
+MODULE YOEVDFS
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOEVDFS
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yomcc1s.F90
+++ b/ifs-source/surf/offline/driver/yomcc1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMCC1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMCC1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomcdh1s.F90
+++ b/ifs-source/surf/offline/driver/yomcdh1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMCDH1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMCDH1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomcst.F90
+++ b/ifs-source/surf/offline/driver/yomcst.F90
@@ -1,11 +1,11 @@
+MODULE YOMCST
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMCST
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yomct01s.F90
+++ b/ifs-source/surf/offline/driver/yomct01s.F90
@@ -1,11 +1,11 @@
+MODULE YOMCT01S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMCT01S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomdim1s.F90
+++ b/ifs-source/surf/offline/driver/yomdim1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMDIM1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMDIM1S
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yomdphy.F90
+++ b/ifs-source/surf/offline/driver/yomdphy.F90
@@ -1,11 +1,11 @@
+MODULE YOMDPHY
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMDPHY
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 USE ISO_C_BINDING

--- a/ifs-source/surf/offline/driver/yomdyn1s.F90
+++ b/ifs-source/surf/offline/driver/yomdyn1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMDYN1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMDYN1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomforc1s.F90
+++ b/ifs-source/surf/offline/driver/yomforc1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMFORC1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMFORC1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB, JPRD
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomgc1s.F90
+++ b/ifs-source/surf/offline/driver/yomgc1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMGC1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGC1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomgdi1s.F90
+++ b/ifs-source/surf/offline/driver/yomgdi1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMGDI1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGDI1S
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yomgf1s.F90
+++ b/ifs-source/surf/offline/driver/yomgf1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMGF1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGF1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomgp1s0.F90
+++ b/ifs-source/surf/offline/driver/yomgp1s0.F90
@@ -1,11 +1,11 @@
+MODULE YOMGP1S0
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGP1S0
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomgp1s1.F90
+++ b/ifs-source/surf/offline/driver/yomgp1s1.F90
@@ -1,11 +1,11 @@
+MODULE YOMGP1S1
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGP1S1
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomgp1sa.F90
+++ b/ifs-source/surf/offline/driver/yomgp1sa.F90
@@ -1,11 +1,11 @@
+MODULE YOMGP1SA
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGP1SA
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomgpd1s.F90
+++ b/ifs-source/surf/offline/driver/yomgpd1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMGPD1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMGPD1S
+! nor does it submit to any jurisdiction.
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomjfh.F90
+++ b/ifs-source/surf/offline/driver/yomjfh.F90
@@ -1,11 +1,11 @@
+MODULE YOMJFH
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMJFH
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 

--- a/ifs-source/surf/offline/driver/yomlog1s.F90
+++ b/ifs-source/surf/offline/driver/yomlog1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMLOG1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMLOG1S
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomlun1s.F90
+++ b/ifs-source/surf/offline/driver/yomlun1s.F90
@@ -1,11 +1,11 @@
+MODULE YOMLUN1S
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMLUN1S
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB, JPRD,JPRM
 IMPLICIT NONE

--- a/ifs-source/surf/offline/driver/yomrip.F90
+++ b/ifs-source/surf/offline/driver/yomrip.F90
@@ -1,11 +1,11 @@
+MODULE YOMRIP
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-MODULE YOMRIP
+! nor does it submit to any jurisdiction.
 
 USE PARKIND1  ,ONLY : JPIM     ,JPRB, JPRD
 

--- a/ifs-source/surf/offline/function/fctast.h
+++ b/ifs-source/surf/offline/function/fctast.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !      -----------------------------------------------------------
 
 ! - Astronomical functions

--- a/ifs-source/surf/offline/function/fcttim.h
+++ b/ifs-source/surf/offline/function/fcttim.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 
 ! - Time functions

--- a/ifs-source/surf/offline/function/fcttre.h
+++ b/ifs-source/surf/offline/function/fcttre.h
@@ -1,11 +1,12 @@
+!*
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
-!*
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 #ifdef DOC
 

--- a/ifs-source/surf/offline/function/fcttrm.h
+++ b/ifs-source/surf/offline/function/fcttrm.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !*
 !     ------------------------------------------------------------------
 #ifdef DOC

--- a/ifs-source/surf/offline/function/fcvdfs.h
+++ b/ifs-source/surf/offline/function/fcvdfs.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 1990- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 
 !     ------------------------------------------------------------------
 

--- a/ifs-source/surf/offline/master1s.F90
+++ b/ifs-source/surf/offline/master1s.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 PROGRAM MASTER1S
 USE PARKIND1  ,ONLY : JPRD, JPIM
 USE YOMLUN1S , ONLY : NULOUT

--- a/ifs-source/surf/offline/namelist/nam1s.h
+++ b/ifs-source/surf/offline/namelist/nam1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !*    -----------------------------------------------------------------
 NAMELIST/NAM1S/ LDBGS1 , LACCUMW , LSEMISS , CFFORC , CMODID , &
                &CVERID , LRESET  , NACCUR  , NDIMCDF,&

--- a/ifs-source/surf/offline/namelist/namct01s.h
+++ b/ifs-source/surf/offline/namelist/namct01s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !*    ------------------------------------------------------------------
 NAMELIST/NAMCT01S/LNF,LMPLOT, NFRPLT, NCYCLE &
               &,CNMEXP &

--- a/ifs-source/surf/offline/namelist/namdim1s.h
+++ b/ifs-source/surf/offline/namelist/namdim1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !*    -----------------------------------------------------------------
 NAMELIST/NAMDIM/ NLON,NLAT,NDFORC,NCOOR,NPROMA,NCSNEC,NCSS
 !     -----------------------------------------------------------------

--- a/ifs-source/surf/offline/namelist/namdyn1s.h
+++ b/ifs-source/surf/offline/namelist/namdyn1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 NAMELIST/NAMDYN1S/TSTEP ,TDT, NACCTYPE,LPREINT,LSWINT,LFLXINT,TCOUPFREQ
 !     ------------------------------------------------------------------

--- a/ifs-source/surf/offline/namelist/namforc1s.h
+++ b/ifs-source/surf/offline/namelist/namforc1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !*    -----------------------------------------------------------------
 !     FORCING PROPERTIES
 

--- a/ifs-source/surf/offline/namelist/namgc1s.h
+++ b/ifs-source/surf/offline/namelist/namgc1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 REAL(KIND=JPRB) :: RLAT,RLON,RMASK
 !*    ------------------------------------------------------------------
 NAMELIST/NAMGC1S/RLAT,RLON,RMASK

--- a/ifs-source/surf/offline/namelist/namgp1s.h
+++ b/ifs-source/surf/offline/namelist/namgp1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !*    ------------------------------------------------------------------
 NAMELIST/NAMGP1S/TSLNU,QLINU,TILNU,FSNNU,TSNNU,ASNNU,RSNNU,&
                 &TRENU,WRENU,&

--- a/ifs-source/surf/offline/namelist/namgpd1s.h
+++ b/ifs-source/surf/offline/namelist/namgpd1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 REAL(KIND=JPRB) :: VALBF(12)
 REAL(KIND=JPRB) :: VLAIL(12)
 REAL(KIND=JPRB) :: VLAIH(12)

--- a/ifs-source/surf/offline/namelist/namoptsurf.h
+++ b/ifs-source/surf/offline/namelist/namoptsurf.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 NAMELIST/NAMOPTSURF/ OVR0VT, OVCMAX25 ,OHUMREL, OA1, OB1, OG0, &
  & OGM25, OE_VCMAX, OE_JMAX

--- a/ifs-source/surf/offline/namelist/namphy1s.h
+++ b/ifs-source/surf/offline/namelist/namphy1s.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 NAMELIST/NAMPHY/ LERADS   ,LESICE   ,LESURF   ,LEVDIF, &
  & LEOCWA,LEOCCO,LEOCSA, LEVGEN, LESSRO, LESN09, &

--- a/ifs-source/surf/offline/namelist/namrip.h
+++ b/ifs-source/surf/offline/namelist/namrip.h
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !     ------------------------------------------------------------------
 NAMELIST/NAMRIP/NINDAT,NSSSSS
 !     ------------------------------------------------------------------

--- a/ifs-source/surf/offline/util/adjust_forc.F90
+++ b/ifs-source/surf/offline/util/adjust_forc.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !
 program adjust_for
 use grib_api

--- a/ifs-source/surf/offline/util/caldtdz.F90
+++ b/ifs-source/surf/offline/util/caldtdz.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 !
 program caldtdz
 use grib_api

--- a/ifs-source/surf/offline/util/convNetcdf2Grib.F90
+++ b/ifs-source/surf/offline/util/convNetcdf2Grib.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 
 
 PROGRAM CONVNETCDF2GRIB

--- a/ifs-source/surf/offline/util/conv_forcing.F90
+++ b/ifs-source/surf/offline/util/conv_forcing.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 MODULE CONV_FORCING_MODS
 
 CONTAINS

--- a/ifs-source/surf/offline/util/create_grid_info.F90
+++ b/ifs-source/surf/offline/util/create_grid_info.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 PROGRAM CREATE_GRID_INFO
 USE NETCDF
 USE GRIB_API

--- a/ifs-source/surf/offline/util/create_init_clim.F90
+++ b/ifs-source/surf/offline/util/create_init_clim.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 PROGRAM CREATE_INIT_CLIM
 USE NETCDF
 USE GET_POINTS_MOD

--- a/ifs-source/surf/offline/util/find_points.F90
+++ b/ifs-source/surf/offline/util/find_points.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 PROGRAM FIND_POINTS
 USE NETCDF
 USE GET_POINTS_MOD

--- a/ifs-source/surf/offline/util/get_points_mod.F90
+++ b/ifs-source/surf/offline/util/get_points_mod.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 MODULE GET_POINTS_MOD
 
 CONTAINS

--- a/ifs-source/surf/offline/util/lib_dates.F90
+++ b/ifs-source/surf/offline/util/lib_dates.F90
@@ -1,10 +1,11 @@
 ! (C) Copyright 2005- ECMWF.
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
-! 
 ! In applying this licence, ECMWF does not waive the privileges and immunities
 ! granted to it by virtue of its status as an intergovernmental organisation
-! nor does it submit to any jurisdiction
+! nor does it submit to any jurisdiction.
+
 MODULE lib_dates
 
 IMPLICIT NONE

--- a/ifs-test/bin/storage.py
+++ b/ifs-test/bin/storage.py
@@ -2,6 +2,7 @@
 
 import logging
 import pathlib
+import os
 import re
 import shutil
 import urllib.error
@@ -28,6 +29,8 @@ class DataSource:
     :param source_path:     The relative path to the source file.
     :param target_path:     The absolute path where the targe file should be
                             placed.
+    
+    :raises:                RuntimeError, if the operation failed.
     """
     return NotImplemented
 
@@ -48,6 +51,9 @@ class FileSource(DataSource):
 
     if not source_path.exists():
       raise RuntimeError("The source file %s does not exist!" % source_path)
+
+    if not os.access(source_path, os.R_OK):
+      raise RuntimeError("The source file %s lacks the necessary read permissions." % source_path)
 
     target_path.parent.mkdir(parents=True, exist_ok=True)
     target_path.unlink(missing_ok=True)
@@ -129,6 +135,38 @@ def _get_data_sources(config):
 
   return sources
 
+def _fetch_sequential(sources, source_path, target_path):
+  """
+  Fetch a file from the first available source in a source list.
+
+  :param sources:     List of data sources.
+  :param source_path: Relative path of the file with respect to the data
+                      sources. 
+  :param target_path: Path where the fetched file will be placed. The file
+                      must not exist yet.
+  :raises:            RuntimeError
+                      If fetching the file failed for all data sources.
+  """
+
+  success = True
+
+  for source in sources:
+    success = False
+    try:
+      source.fetch(source_path, target_path)
+      success = True
+      break
+    except RuntimeError as re:
+      logging.debug(f"Fetching {source_path} from {source} failed ({str(re)}).")
+    except Exception as ex:
+      # source.fetch should raise a RuntimeError if fetching wasn't succesful.
+      # To be safe, catch other exceptions here, too.
+      logging.critical(f"Unexpected failure when fetching {source_path} from {source}: {str(ex)}!")
+
+  if not success:
+    raise RuntimeError(f"Fetching {source_path} failed!")
+
+
 @click.group()
 @click.option('-v', 'verbosity', count=True)
 def cli(verbosity):
@@ -205,17 +243,7 @@ def fetch(config_file, output_dir, force, custom_path):
     if target_path.exists():
       logging.debug(f"Skip file {target_path} (file exists).")
     else:
-      for source in sources:
-        success = False
-        try:
-          source.fetch(source_path, target_path)
-          success = True
-          break
-        except RuntimeError as re:
-          logging.debug(f"Fetching {source_path} from {source} failed.")
-
-      if not success:
-        raise RuntimeError(f"Fetching {source_path} failed!")
+      _fetch_sequential(sources, source_path, target_path)
 
     if extract_path is not None:
       extract_path = output_dir/extract_path
@@ -291,17 +319,7 @@ def cache(config_file, output_dir, force, custom_path):
     if target_path.exists():
       logging.debug(f"Skip file {target_path} (file exists).")
     else:
-      for source in sources:
-        success = False
-        try:
-          source.fetch(source_path, target_path)
-          success = True
-          break
-        except RuntimeError as re:
-          logging.debug(f"Fetching {source_path} from {source} failed.")
-
-      if not success:
-        raise RuntimeError(f"Fetching {source_path} failed!")
+      _fetch_sequential(sources, source_path, target_path)
 
   logging.info("Caching data finished. Data has been placed in %s." % output_dir)
 


### PR DESCRIPTION
## Summary
This PR brings the latest 2 changes (#15 and #14) from `ecmwf-ifs/openifs/openifs-lts/CY48R1.1` into main.

## Changes
- Fix/surf headers match ecland (#14)
    * Align the surf copyright statement text and placement in all .F90 and .h files with the equivalent in ecland v1.0.0, request from EC-Earth deveopers.
- Modified the storage.py based on IFS-3817
   * Fixed bug which caused ECPDS fetch to fail if local cache could not be read due to permissions.
    This is a problem with non-EC users of ATOS. The attached change checks for the existence of a root dir. If it exists but can't be accessed or read, the script tries other sources in the storage yaml.
    Based on bitbucket ifs-test commit hash a8544a4fe46. Tested in a docker and appears to work.

## Notes
- Syncs main with the openifs-lts/CY48R1.1 branch.
- No functional changes beyond the commits listed above. 